### PR TITLE
[FEAT] 프로젝트 선택 탭 추가

### DIFF
--- a/src/components/common/Tabs/ProjectSelectTab/ProjectSelectTab.module.css
+++ b/src/components/common/Tabs/ProjectSelectTab/ProjectSelectTab.module.css
@@ -1,0 +1,28 @@
+.element {
+  background-color: var(--color-background);
+  width: 100%;
+}
+
+.tablist {
+  border: none;
+}
+
+.tab {
+  background-color: none;
+  margin: 10px 40px;
+  border-radius: 8px;
+  border-bottom: 0;
+  font-weight: var(--mantine-other-font-weights-semibold);
+  font-size: 24px;
+
+  width: 20%;
+  height: 60px;
+}
+
+.activeTab {
+  background-color: var(--color-surfaceVariant);
+}
+
+.panel {
+  padding-top: 20px;
+}

--- a/src/components/common/Tabs/ProjectSelectTab/ProjectSelectTab.story.tsx
+++ b/src/components/common/Tabs/ProjectSelectTab/ProjectSelectTab.story.tsx
@@ -28,12 +28,12 @@ export const Usage: Story = {
       {
         id: "1",
         label: "S-TOP 이벤트 프로젝트",
-        content: <Container>S-TOP 이벤트 프로젝트 내용입니다.</Container>,
+        children: <Container>S-TOP 이벤트 프로젝트 내용입니다.</Container>,
       },
       {
         id: "2",
         label: "전체 프로젝트",
-        content: <Container>전체 프로젝트 내용입니다.</Container>,
+        children: <Container>전체 프로젝트 내용입니다.</Container>,
       },
     ],
     defaultTabId: "1",

--- a/src/components/common/Tabs/ProjectSelectTab/ProjectSelectTab.story.tsx
+++ b/src/components/common/Tabs/ProjectSelectTab/ProjectSelectTab.story.tsx
@@ -1,0 +1,46 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { ProjectSelectTab } from "./ProjectSelectTab";
+import { Container } from "@mantine/core";
+
+// More on how to set up stories at: https://storybook.js.org/docs/writing-stories#default-export
+const meta = {
+  title: "Project Select Tab",
+  component: ProjectSelectTab,
+  parameters: {
+    // Optional parameter to center the component in the Canvas. More info: https://storybook.js.org/docs/configure/story-layout
+    layout: "center",
+  },
+  // This component will have an automatically generated Autodocs entry: https://storybook.js.org/docs/writing-docs/autodocs
+  tags: ["autodocs"],
+  // More on argTypes: https://storybook.js.org/docs/api/argtypes
+  argTypes: {},
+  // More on Action Args : https://storybook.js.org/docs/essentials/actions#action-args
+  args: {},
+} satisfies Meta<typeof ProjectSelectTab>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// More on writing stories with args: https://storybook.js.org/docs/writing-stories/args
+export const Usage: Story = {
+  args: {
+    tabs: [
+      {
+        id: "1",
+        label: "S-TOP 이벤트 프로젝트",
+        content: <Container>S-TOP 이벤트 프로젝트 내용입니다.</Container>,
+      },
+      {
+        id: "2",
+        label: "전체 프로젝트",
+        content: <Container>전체 프로젝트 내용입니다.</Container>,
+      },
+    ],
+    defaultTabId: "1",
+  },
+  render: (args) => (
+    <Container style={{ width: "1440px" }}>
+      <ProjectSelectTab {...args} />
+    </Container>
+  ),
+};

--- a/src/components/common/Tabs/ProjectSelectTab/ProjectSelectTab.test.tsx
+++ b/src/components/common/Tabs/ProjectSelectTab/ProjectSelectTab.test.tsx
@@ -1,0 +1,28 @@
+import { render, screen } from "@/utils/test-utils";
+import { ProjectSelectTab, TabType } from "./ProjectSelectTab";
+import "@testing-library/jest-dom";
+
+describe("Project Select Tab component", () => {
+  it("renders the correct default tab", () => {
+    const tabs: TabType[] = [
+      { id: "1", label: "Tab 1", content: "Tab 1 content" },
+      { id: "2", label: "Tab 2", content: "Tab 2 content" },
+    ];
+    render(<ProjectSelectTab tabs={tabs} defaultTabId={"2"} />);
+
+    expect(screen.getByText("Tab 2 content")).toBeInTheDocument();
+  });
+
+  it("renders all the tab labels provided", () => {
+    const tabs = [
+      { id: "1", label: "Tab 1", content: "Tab 1 content" },
+      { id: "2", label: "Tab 2", content: "Tab 2 content" },
+      { id: "3", label: "Tab 3", content: "Tab 3 content" },
+    ];
+    render(<ProjectSelectTab tabs={tabs} defaultTabId={"1"} />);
+
+    tabs.forEach((tab) => {
+      expect(screen.getByText(tab.label)).toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/common/Tabs/ProjectSelectTab/ProjectSelectTab.test.tsx
+++ b/src/components/common/Tabs/ProjectSelectTab/ProjectSelectTab.test.tsx
@@ -5,8 +5,8 @@ import "@testing-library/jest-dom";
 describe("Project Select Tab component", () => {
   it("renders the correct default tab", () => {
     const tabs: TabType[] = [
-      { id: "1", label: "Tab 1", content: "Tab 1 content" },
-      { id: "2", label: "Tab 2", content: "Tab 2 content" },
+      { id: "1", label: "Tab 1", children: "Tab 1 content" },
+      { id: "2", label: "Tab 2", children: "Tab 2 content" },
     ];
     render(<ProjectSelectTab tabs={tabs} defaultTabId={"2"} />);
 
@@ -15,9 +15,9 @@ describe("Project Select Tab component", () => {
 
   it("renders all the tab labels provided", () => {
     const tabs = [
-      { id: "1", label: "Tab 1", content: "Tab 1 content" },
-      { id: "2", label: "Tab 2", content: "Tab 2 content" },
-      { id: "3", label: "Tab 3", content: "Tab 3 content" },
+      { id: "1", label: "Tab 1", children: "Tab 1 content" },
+      { id: "2", label: "Tab 2", children: "Tab 2 content" },
+      { id: "3", label: "Tab 3", children: "Tab 3 content" },
     ];
     render(<ProjectSelectTab tabs={tabs} defaultTabId={"1"} />);
 

--- a/src/components/common/Tabs/ProjectSelectTab/ProjectSelectTab.tsx
+++ b/src/components/common/Tabs/ProjectSelectTab/ProjectSelectTab.tsx
@@ -1,6 +1,6 @@
 import classes from "./ProjectSelectTab.module.css";
 import { ReactNode, useState } from "react";
-import { Tabs, TabsProps } from "@mantine/core";
+import { Tabs, TabsList, TabsPanel, TabsProps, TabsTab } from "@mantine/core";
 
 export interface TabType {
   id: string;
@@ -25,21 +25,21 @@ export function ProjectSelectTab({
   return (
     <>
       <Tabs value={activeTab} onChange={setActiveTab} className={classes.element} {...props}>
-        <Tabs.List grow={grow} className={classes.tablist}>
+        <TabsList grow={grow} className={classes.tablist}>
           {tabs.map((tab, index) => (
-            <Tabs.Tab
+            <TabsTab
               key={index}
               value={tab.id}
               className={`${classes.tab} ${activeTab === tab.id ? classes.activeTab : ""}`}
             >
               {tab.label}
-            </Tabs.Tab>
+            </TabsTab>
           ))}
-        </Tabs.List>
+        </TabsList>
         {tabs.map((tab, index) => (
-          <Tabs.Panel key={index} value={tab.id} className={classes.panel}>
+          <TabsPanel key={index} value={tab.id} className={classes.panel}>
             {tab.content}
-          </Tabs.Panel>
+          </TabsPanel>
         ))}
       </Tabs>
     </>

--- a/src/components/common/Tabs/ProjectSelectTab/ProjectSelectTab.tsx
+++ b/src/components/common/Tabs/ProjectSelectTab/ProjectSelectTab.tsx
@@ -1,0 +1,47 @@
+import classes from "./ProjectSelectTab.module.css";
+import { ReactNode, useState } from "react";
+import { Tabs, TabsProps } from "@mantine/core";
+
+export interface TabType {
+  id: string;
+  label: string;
+  content: ReactNode;
+}
+
+interface Props {
+  tabs: TabType[];
+  defaultTabId: string | null;
+  grow?: boolean;
+}
+
+export function ProjectSelectTab({
+  tabs,
+  defaultTabId = null,
+  grow = true,
+  ...props
+}: TabsProps & Props) {
+  const [activeTab, setActiveTab] = useState<string | null>(defaultTabId);
+
+  return (
+    <>
+      <Tabs value={activeTab} onChange={setActiveTab} className={classes.element} {...props}>
+        <Tabs.List grow={grow} className={classes.tablist}>
+          {tabs.map((tab, index) => (
+            <Tabs.Tab
+              key={index}
+              value={tab.id}
+              className={`${classes.tab} ${activeTab === tab.id ? classes.activeTab : ""}`}
+            >
+              {tab.label}
+            </Tabs.Tab>
+          ))}
+        </Tabs.List>
+        {tabs.map((tab, index) => (
+          <Tabs.Panel key={index} value={tab.id} className={classes.panel}>
+            {tab.content}
+          </Tabs.Panel>
+        ))}
+      </Tabs>
+    </>
+  );
+}

--- a/src/components/common/Tabs/ProjectSelectTab/ProjectSelectTab.tsx
+++ b/src/components/common/Tabs/ProjectSelectTab/ProjectSelectTab.tsx
@@ -5,7 +5,7 @@ import { Tabs, TabsList, TabsPanel, TabsProps, TabsTab } from "@mantine/core";
 export interface TabType {
   id: string;
   label: string;
-  content: ReactNode;
+  children: ReactNode;
 }
 
 interface Props {
@@ -38,7 +38,7 @@ export function ProjectSelectTab({
         </TabsList>
         {tabs.map((tab, index) => (
           <TabsPanel key={index} value={tab.id} className={classes.panel}>
-            {tab.content}
+            {tab.children}
           </TabsPanel>
         ))}
       </Tabs>

--- a/src/components/common/Tabs/index.ts
+++ b/src/components/common/Tabs/index.ts
@@ -1,0 +1,1 @@
+export { ProjectSelectTab } from "./ProjectSelectTab/ProjectSelectTab";

--- a/src/theme/AppTheme.ts
+++ b/src/theme/AppTheme.ts
@@ -19,6 +19,7 @@ export const AppTheme = createTheme({
   other: {
     fontWeights: {
       regular: 400,
+      semibold: 600,
       bold: 700,
     },
     // 피그마 기준 색상 설정
@@ -130,6 +131,7 @@ export const AppTheme = createTheme({
 export const resolver: CSSVariablesResolver = (theme) => ({
   variables: {
     "--mantine-other-font-weights-regular": theme.other.fontWeights.regular,
+    "--mantine-other-font-weights-semibold": theme.other.fontWeights.semibold,
     "--mantine-other-font-weights-bold": theme.other.fontWeights.bold,
   },
   dark: {


### PR DESCRIPTION
작성자: @sera2002 
이슈: #8 

## 체크 리스트

- [x] 적절한 제목으로 수정했나요?
- [x] 상단에 이슈 번호를 기입했나요?
- [x] Target Branch를 올바르게 설정했나요?
- [x] Label을 알맞게 설정했나요?

## 작업 내역

- 프로젝트 선택 탭을 추가하였습니다.

## 비고

- 스토리 canvas 너비 제한 때문에 탭 부분이 줄바꿈이 되어 보이는데, 실제로 페이지에 적용하면 정상적으로 표시되긴 합니다.

close/resolve/fix #{이슈 번호 기입}
