### PR TITLE
[FIX] ease-in-out transition n storybook layout fullscreen

### DIFF
--- a/src/components/common/Header/Header.module.css
+++ b/src/components/common/Header/Header.module.css
@@ -8,8 +8,8 @@
   --color-coverHover: #f5f5f5;
 }
 
-/* [color-theme="dark"] { */
-:root {
+[color-theme="dark"] {
+  /* :root { */
   --color-text: #c9c9c9;
   --color-darkText: #c9c9c9;
   --color-description: #888;

--- a/src/components/common/Header/Header.module.css
+++ b/src/components/common/Header/Header.module.css
@@ -8,8 +8,8 @@
   --color-coverHover: #f5f5f5;
 }
 
-[color-theme="dark"] {
-  /* :root { */
+/* [color-theme="dark"] { */
+:root {
   --color-text: #c9c9c9;
   --color-darkText: #c9c9c9;
   --color-description: #888;
@@ -134,6 +134,7 @@
   display: flex;
   flex-direction: row;
   align-items: center;
+  gap: 10px;
   color: var(--color-text);
 
   @media screen and (max-width: 1277px) {
@@ -249,13 +250,18 @@
   z-index: 10;
   width: 100%;
   display: flex;
-  opacity: 0;
   flex-direction: row;
   justify-content: space-between;
   gap: 20px;
+
   color: var(--color-darkText);
   background-color: #353535;
-  transition: 0.5s opacity;
+
+  visibility: hidden;
+  opacity: 0;
+  transition:
+    visibility 0.2s,
+    opacity 0.2s ease-in-out;
 
   @media screen and (min-width: 1198px) {
     padding: 100px 180px;
@@ -275,6 +281,7 @@
 }
 
 .show {
+  visibility: visible;
   opacity: 1;
 }
 

--- a/src/components/common/Header/Header.story.tsx
+++ b/src/components/common/Header/Header.story.tsx
@@ -7,7 +7,7 @@ const meta = {
   component: Header,
   parameters: {
     // Optional parameter to center the component in the Canvas. More info: https://storybook.js.org/docs/configure/story-layout
-    layout: "left",
+    layout: "fullscreen",
   },
   // This component will have an automatically generated Autodocs entry: https://storybook.js.org/docs/writing-docs/autodocs
   tags: ["autodocs"],


### PR DESCRIPTION
작성자: @chunzhi23 
Issue: #47 

## 체크 리스트

- [x] 적절한 제목으로 수정했나요?
- [x] 상단에 이슈 번호를 기입했나요?
- [x] Target Branch를 올바르게 설정했나요?
- [x] Label을 알맞게 설정했나요?

## 작업 내역

- fade in/out 스타일을 구현하는 데에 display 대신 visibility를 사용
- transition visibility n opacity

## 비고

- https://stackoverflow.com/questions/3331353/transitions-on-the-css-display-property