### PR TITLE
[FEAT] 로그인, 로그아웃 모듈 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@types/js-cookie": "^3.0.6",
         "axios": "^1.7.3",
         "js-cookie": "^3.0.5",
+        "jwt-decode": "^4.0.0",
         "next": "14.2.4",
         "react": "^18",
         "react-dom": "^18"
@@ -13912,6 +13913,15 @@
       },
       "engines": {
         "node": ">=4.0"
+      }
+    },
+    "node_modules/jwt-decode": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-4.0.0.tgz",
+      "integrity": "sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/keyv": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,9 @@
         "@mantine/hooks": "^7.11.2",
         "@mantine/styles": "^6.0.22",
         "@tabler/icons-react": "^3.11.0",
+        "@types/js-cookie": "^3.0.6",
+        "axios": "^1.7.3",
+        "js-cookie": "^3.0.5",
         "next": "14.2.4",
         "react": "^18",
         "react-dom": "^18"
@@ -5905,6 +5908,11 @@
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
       "dev": true
     },
+    "node_modules/@types/js-cookie": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/js-cookie/-/js-cookie-3.0.6.tgz",
+      "integrity": "sha512-wkw9yd1kEXOPnvEeEV1Go1MmxtBJL0RR79aOTAApecWFVu7w0NNXNqhcWgvw2YgZDYadliXkl14pa3WXw5jlCQ=="
+    },
     "node_modules/@types/jsdom": {
       "version": "20.0.1",
       "resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-20.0.1.tgz",
@@ -7098,8 +7106,7 @@
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "dev": true
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
@@ -7123,6 +7130,16 @@
       "dev": true,
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.3.tgz",
+      "integrity": "sha512-Ar7ND9pU99eJ9GpoGQKhKf58GpUOgnzuaB7ueNQ5BMi0p+LZ5oaEnfF999fAArcTIBwXTCHAmGcHOZJaWPq9Nw==",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/axobject-query": {
@@ -8404,7 +8421,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "dependencies": {
         "delayed-stream": "~1.0.0"
       },
@@ -9018,7 +9034,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "dev": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -10874,6 +10889,25 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.6",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
+      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/for-each": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
@@ -10963,7 +10997,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
       "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-      "dev": true,
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -13699,6 +13732,14 @@
         "jiti": "bin/jiti.js"
       }
     },
+    "node_modules/js-cookie": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.5.tgz",
+      "integrity": "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -14532,7 +14573,6 @@
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "dev": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -14541,7 +14581,6 @@
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dev": true,
       "dependencies": {
         "mime-db": "1.52.0"
       },
@@ -16020,6 +16059,11 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "node_modules/psl": {
       "version": "1.9.0",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@types/js-cookie": "^3.0.6",
     "axios": "^1.7.3",
     "js-cookie": "^3.0.5",
+    "jwt-decode": "^4.0.0",
     "next": "14.2.4",
     "react": "^18",
     "react-dom": "^18"

--- a/package.json
+++ b/package.json
@@ -22,6 +22,9 @@
     "@mantine/hooks": "^7.11.2",
     "@mantine/styles": "^6.0.22",
     "@tabler/icons-react": "^3.11.0",
+    "@types/js-cookie": "^3.0.6",
+    "axios": "^1.7.3",
+    "js-cookie": "^3.0.5",
     "next": "14.2.4",
     "react": "^18",
     "react-dom": "^18"

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import { ColorSchemeScript, MantineProvider } from "@mantine/core";
 import "@mantine/core/styles.css";
 import "@/theme/global.css";
 import type { Metadata } from "next";
+import { AuthProvider } from "@/components/common/Auth";
 
 export const metadata: Metadata = {
   title: "S-TOP 기술교류회",
@@ -21,7 +22,7 @@ export default function RootLayout({
       </head>
       <body>
         <MantineProvider theme={AppTheme} cssVariablesResolver={resolver} defaultColorScheme="auto">
-          {children}
+          <AuthProvider>{children}</AuthProvider>
         </MantineProvider>
       </body>
     </html>

--- a/src/app/login/kakao/page.tsx
+++ b/src/app/login/kakao/page.tsx
@@ -1,10 +1,5 @@
 import { KakaoAuth } from "@/components/pages/KakaoAuth";
-import { Suspense } from "react";
 
 export default function KakaoAuthPage() {
-  return (
-    <Suspense>
-      <KakaoAuth />
-    </Suspense>
-  );
+  return <KakaoAuth />;
 }

--- a/src/app/login/kakao/page.tsx
+++ b/src/app/login/kakao/page.tsx
@@ -1,50 +1,10 @@
-"use client";
+import { KakaoAuth } from "@/components/pages/KakaoAuth";
+import { Suspense } from "react";
 
-import { useAuth } from "@/components/common/Auth";
-import { fetcher } from "@/utils/fetcher/fetcher";
-import { useRouter, useSearchParams } from "next/navigation";
-import { useCallback, useEffect } from "react";
-
-interface ResponseType {
-  accessToken: string;
-}
-
-export default function Kakao() {
-  const searchParams = useSearchParams();
-  const router = useRouter();
-  const { login } = useAuth();
-
-  const code = searchParams.get("code");
-  const error = searchParams.get("error");
-
-  const loginHandler = useCallback(
-    async (code: string | string[]) => {
-      // 백엔드 auth api
-      const response: ResponseType = await fetcher({
-        url: "http://localhost:8000/auth/login/kakao",
-        query: { code: code },
-      });
-      if (response) {
-        // Context에 토큰 저장
-        console.log(response.accessToken);
-        login(response.accessToken);
-        router.push("/");
-      } else {
-        // 백엔드 통신 오류
-        router.push("/");
-      }
-    },
-    [router, login]
+export default function KakaoAuthPage() {
+  return (
+    <Suspense>
+      <KakaoAuth />
+    </Suspense>
   );
-
-  useEffect(() => {
-    if (code) {
-      loginHandler(code);
-    } else if (error) {
-      // 카카오 통신 오류
-      router.push("/");
-    }
-  }, [code]);
-
-  return <></>;
 }

--- a/src/app/login/kakao/page.tsx
+++ b/src/app/login/kakao/page.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { useAuth } from "@/components/common/Auth";
+import { fetcher } from "@/utils/fetcher/fetcher";
+import { useRouter, useSearchParams } from "next/navigation";
+import { useCallback, useEffect } from "react";
+
+interface ResponseType {
+  accessToken: string;
+}
+
+export default function Kakao() {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const { login } = useAuth();
+
+  const code = searchParams.get("code");
+  const error = searchParams.get("error");
+
+  const loginHandler = useCallback(
+    async (code: string | string[]) => {
+      // 백엔드 auth api
+      const response: ResponseType = await fetcher({
+        url: "http://localhost:8000/auth/login/kakao",
+        query: { code: code },
+      });
+      if (response) {
+        // Context에 토큰 저장
+        console.log(response.accessToken);
+        login(response.accessToken);
+        router.push("/");
+      } else {
+        // 백엔드 통신 오류
+        router.push("/");
+      }
+    },
+    [router, login]
+  );
+
+  useEffect(() => {
+    if (code) {
+      loginHandler(code);
+    } else if (error) {
+      // 카카오 통신 오류
+      router.push("/");
+    }
+  }, [code]);
+
+  return <></>;
+}

--- a/src/components/common/Auth/AuthProvider.tsx
+++ b/src/components/common/Auth/AuthProvider.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import { createContext, useContext, useEffect, useState } from "react";
+import { JWT_COOKIE_NAME, JWT_MAX_AGE } from "@/constants/Auth";
+import { CommonAxios } from "@/utils/CommonAxios";
+import Cookies from "js-cookie";
+
+interface AuthContextValue {
+  token: string | null;
+  login: (token: string) => void;
+  logout: () => void;
+  isLoggedIn: boolean;
+  isLoading: boolean;
+}
+
+const AuthContext = createContext<AuthContextValue | null>(null);
+
+export function AuthProvider({ children }: { children: React.ReactNode }) {
+  const [token, setToken] = useState<string | null>(null);
+  const [isLoadingCookie, setIsLoadingCookie] = useState(true);
+
+  // fetch previous token
+  useEffect(() => {
+    setIsLoadingCookie(true);
+
+    const previousToken = Cookies.get(JWT_COOKIE_NAME);
+    if (previousToken) {
+      setToken(previousToken);
+      CommonAxios.defaults.headers.Authorization = `Bearer ${token}`;
+      CommonAxios.defaults.withCredentials = true;
+    } else {
+      setToken(null);
+    }
+
+    setIsLoadingCookie(false);
+  }, [token]);
+
+  function login(token: string) {
+    setIsLoadingCookie(true);
+
+    setToken(token);
+    CommonAxios.defaults.headers.Authorization = `Bearer ${token}`;
+    Cookies.set(JWT_COOKIE_NAME, token, { "max-age": String(JWT_MAX_AGE) });
+
+    setIsLoadingCookie(false);
+  }
+
+  function logout() {
+    setIsLoadingCookie(true);
+
+    CommonAxios.post("/auth/logout");
+    setToken(null);
+    Cookies.remove(JWT_COOKIE_NAME);
+    CommonAxios.defaults.withCredentials = false;
+
+    setIsLoadingCookie(false);
+    window.location.replace("/");
+  }
+
+  return (
+    <AuthContext.Provider
+      value={{ token, login, logout, isLoggedIn: !!token, isLoading: isLoadingCookie }}
+    >
+      {children}
+    </AuthContext.Provider>
+  );
+}
+
+export function useAuth() {
+  const context = useContext(AuthContext);
+
+  if (context == null) {
+    throw new Error("Error: Please use inside AuthProvider");
+  }
+
+  return context;
+}

--- a/src/components/common/Auth/AuthProvider.tsx
+++ b/src/components/common/Auth/AuthProvider.tsx
@@ -41,7 +41,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     setToken(token);
     CommonAxios.defaults.headers.Authorization = `Bearer ${token}`;
     CommonAxios.defaults.withCredentials = true;
-    Cookies.set(JWT_COOKIE_NAME, token, { "max-age": String(JWT_MAX_AGE) });
+    Cookies.set(JWT_COOKIE_NAME, token, { "max-age": String(JWT_MAX_AGE), secure: true });
 
     setIsLoadingCookie(false);
   }

--- a/src/components/common/Auth/AuthProvider.tsx
+++ b/src/components/common/Auth/AuthProvider.tsx
@@ -40,6 +40,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
     setToken(token);
     CommonAxios.defaults.headers.Authorization = `Bearer ${token}`;
+    CommonAxios.defaults.withCredentials = true;
     Cookies.set(JWT_COOKIE_NAME, token, { "max-age": String(JWT_MAX_AGE) });
 
     setIsLoadingCookie(false);

--- a/src/components/common/Auth/getServerSideToken.ts
+++ b/src/components/common/Auth/getServerSideToken.ts
@@ -1,11 +1,12 @@
 "use server";
 
-import { JWT_COOKIE_NAME } from "@/constants/Auth";
+import { JWT_COOKIE_NAME, REFRESH_TOKEN_NAME } from "@/constants/Auth";
 import { cookies } from "next/headers";
 
 export async function getServerSideToken() {
   const cookie = cookies();
-  const token = cookie.get(JWT_COOKIE_NAME)?.value || null;
+  const accessToken = cookie.get(JWT_COOKIE_NAME)?.value || null;
+  const refreshToken = cookie.get(REFRESH_TOKEN_NAME)?.value || null;
 
-  return Promise.resolve(token);
+  return Promise.resolve({ accessToken, refreshToken });
 }

--- a/src/components/common/Auth/getServerSideToken.ts
+++ b/src/components/common/Auth/getServerSideToken.ts
@@ -1,0 +1,11 @@
+"use server";
+
+import { JWT_COOKIE_NAME } from "@/constants/Auth";
+import { cookies } from "next/headers";
+
+export async function getServerSideToken() {
+  const cookie = cookies();
+  const token = cookie.get(JWT_COOKIE_NAME)?.value || null;
+
+  return Promise.resolve(token);
+}

--- a/src/components/common/Auth/index.ts
+++ b/src/components/common/Auth/index.ts
@@ -1,0 +1,3 @@
+export { AuthProvider } from "./AuthProvider";
+export { useAuth } from "./AuthProvider";
+export { getServerSideToken } from "./getServerSideToken";

--- a/src/components/common/DataTable/DataTableUsage.tsx
+++ b/src/components/common/DataTable/DataTableUsage.tsx
@@ -43,6 +43,7 @@ export function DataTableUsage() {
     });
   };
 
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   const sortedData = useMemo(() => makeSortData(), [toggle, order]);
 
   return (

--- a/src/components/pages/KakaoAuth/KakaoAuth.tsx
+++ b/src/components/pages/KakaoAuth/KakaoAuth.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { useAuth } from "@/components/common/Auth";
+import { fetcher } from "@/utils/fetcher/fetcher";
+import { useRouter, useSearchParams } from "next/navigation";
+import { Suspense, useCallback, useEffect } from "react";
+
+interface ResponseType {
+  accessToken: string;
+}
+
+export function KakaoAuth() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const { login } = useAuth();
+
+  const code = searchParams.get("code");
+  const error = searchParams.get("error");
+
+  const loginHandler = useCallback(
+    async (code: string | string[]) => {
+      // 백엔드 auth api
+      const response: ResponseType = await fetcher({
+        url: "http://localhost:8000/auth/login/kakao",
+        query: { code: code },
+      });
+      if (response) {
+        // Context에 토큰 저장
+        login(response.accessToken);
+        router.push("/");
+      } else {
+        // 백엔드 통신 오류
+        router.push("/");
+      }
+    },
+    [router, login]
+  );
+
+  useEffect(() => {
+    if (code) {
+      loginHandler(code);
+    } else if (error) {
+      // 카카오 통신 오류
+      router.push("/");
+    }
+  }, [code]);
+
+  return (
+    <Suspense>
+      <></>
+    </Suspense>
+  );
+}

--- a/src/components/pages/KakaoAuth/KakaoAuth.tsx
+++ b/src/components/pages/KakaoAuth/KakaoAuth.tsx
@@ -43,6 +43,7 @@ export function KakaoAuth() {
       // 카카오 통신 오류
       router.push("/");
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [code]);
 
   return (

--- a/src/components/pages/KakaoAuth/index.ts
+++ b/src/components/pages/KakaoAuth/index.ts
@@ -1,0 +1,1 @@
+export { KakaoAuth } from "./KakaoAuth";

--- a/src/constants/Auth.ts
+++ b/src/constants/Auth.ts
@@ -1,0 +1,8 @@
+/* 클라이언트 사이드 쿠키에 저장할 액세스토큰 key name */
+export const JWT_COOKIE_NAME = "access-token";
+
+/* 리프레시 토큰 key name */
+export const REFRESH_TOKEN_NAME = "refresh-token";
+
+/* 쿠키 만료 시간 */
+export const JWT_MAX_AGE = 24 * 60 * 60; // 24시간

--- a/src/types/jwtPayload.ts
+++ b/src/types/jwtPayload.ts
@@ -1,0 +1,6 @@
+import { JwtPayload } from "jwt-decode";
+import { Role } from "./user";
+
+export interface CustomJwtPayload extends JwtPayload {
+  type: Role;
+}

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -1,0 +1,9 @@
+export type Role =
+  | "STUDENT"
+  | "PROFESSOR"
+  | "COMPANY"
+  | "ADMIN"
+  | "INACTIVE_PROPESSOR"
+  | "INACTIVE_COMPANY"
+  | "OTHERS"
+  | "TEMP";

--- a/src/utils/CommonAxios/CommonAxios.ts
+++ b/src/utils/CommonAxios/CommonAxios.ts
@@ -1,0 +1,25 @@
+import axios from "axios";
+import { redirect } from "next/navigation";
+
+/**
+ * 클라이언트에서 사용하는 공통 axios
+ * baseURL, token 설정 등의 코드 중복 방지 및 interceptor를 통한 응답 성공/실패 시 행동을 설정하기 위해 사용
+ */
+export const CommonAxios = axios.create({
+  baseURL: process.env.NEXT_PUBLIC_API_ENDPOINT,
+});
+
+CommonAxios.interceptors.response.use(
+  function (response) {
+    // 200번대 정상작동
+    return response;
+  },
+  function (error) {
+    // 400번대 에러
+    if (error.response.status === 401) {
+      redirect("/");
+    }
+
+    return Promise.reject(error);
+  }
+);

--- a/src/utils/CommonAxios/index.ts
+++ b/src/utils/CommonAxios/index.ts
@@ -1,0 +1,1 @@
+export { CommonAxios } from "./CommonAxios";

--- a/src/utils/fetcher/fetcher.ts
+++ b/src/utils/fetcher/fetcher.ts
@@ -1,0 +1,29 @@
+import { REFRESH_TOKEN_NAME } from "@/constants/Auth";
+import { CommonAxios } from "@/utils/CommonAxios";
+
+export interface FetcherArgs {
+  url: string;
+  query?: Record<string, unknown>;
+  accessToken?: string | null;
+  refreshToken?: string | null;
+}
+
+/**
+ * swr, 서버사이드 데이터 패칭에 사용할 수 있는 fetch 대용 함수.
+ * @param url 요청 URL
+ * @param query 쿼리 파라미터
+ * @param accessToken 액세스 토큰 (서버사이드에서 사용)
+ * @param refreshToken 리프레시 토큰 (서버사이드에서 사용)
+ * @returns api 서버로부터 반환되는 데이터
+ */
+export async function fetcher({ url, query, accessToken, refreshToken }: FetcherArgs) {
+  return (
+    await CommonAxios.get(url, {
+      params: query,
+      headers: {
+        Authorization: accessToken ? `Bearer ${accessToken}` : undefined,
+        Cookie: refreshToken ? `${REFRESH_TOKEN_NAME}=${refreshToken}` : undefined,
+      },
+    })
+  ).data;
+}

--- a/src/utils/fetcher/index.ts
+++ b/src/utils/fetcher/index.ts
@@ -1,0 +1,1 @@
+export { fetcher } from "./fetcher";


### PR DESCRIPTION
작성자: @hynseok 

## 체크 리스트

- [x] 적절한 제목으로 수정했나요?
- [x] 상단에 이슈 번호를 기입했나요?
- [x] Target Branch를 올바르게 설정했나요?
- [x] Label을 알맞게 설정했나요?

## 작업 내역

- 백엔드 통신에서 인증시 필요한 accessToken을 관리하는 Auth Context와 Provider를 작성하였습니다.
- baseURL및 accessToken을 요청 기본값으로 설정하여 사용하는 CommonAxios를 작성하였습니다.
- 서버컴포넌트에서 브라우저의 액세스토큰 및 리프레시 토큰을 얻어올 수 있는 getServerSideToken을 작성하였습니다.
- swr 및 서버사이드 데이터페칭에 이용할 수 있는 fetcher 함수를 작성하였습니다.
- 카카오 로그인을 위한 페이지를 작성하였습니다. 로그인페이지에서 카카오 로그인 버튼을 누르면 
https://kauth.kakao.com/oauth/authorize?response_type=code&client_id=<카카오 클라이언트 id>&redirect_uri=<사용하게될 도메인>/auth/login/kakao 
으로 이동하도록 로그인 페이지를 구현하면 됩니다. (cc. @moony1204)


## 비고

close #56 
