### PR TITLE
[FEAT] 관리자페이지용 공통 컴포넌트 추가

### DIFF
--- a/src/components/common/PageHeader/PageHeader.story.tsx
+++ b/src/components/common/PageHeader/PageHeader.story.tsx
@@ -1,0 +1,19 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { PageHeader } from "./PageHeader";
+
+const meta: Meta<typeof PageHeader> = {
+  title: "Components/PageHeader",
+  component: PageHeader,
+  parameters: {
+    layout: "centered",
+  },
+  tags: ["autodocs"],
+  argTypes: {},
+  args: { title: "공지사항 게시판 관리" },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// 기본 Dropdown
+export const Default: Story = {};

--- a/src/components/common/PageHeader/PageHeader.tsx
+++ b/src/components/common/PageHeader/PageHeader.tsx
@@ -1,0 +1,19 @@
+import { Group, Stack, Text, Title } from "@mantine/core";
+
+interface Props {
+  title: string;
+  description?: string;
+}
+
+export function PageHeader({ title, description }: Props) {
+  return (
+    <Group justify="space-between" align="flex-start" style={{ marginBottom: 30 }}>
+      <Stack gap={16}>
+        <Title order={2} fz={32} fw="bold">
+          {title}
+        </Title>
+        {description && <Text fz={16}>{description ?? ""}</Text>}
+      </Stack>
+    </Group>
+  );
+}

--- a/src/components/common/PageHeader/index.ts
+++ b/src/components/common/PageHeader/index.ts
@@ -1,0 +1,1 @@
+export { PageHeader } from "./PageHeader";

--- a/src/components/common/Row/Row.module.css
+++ b/src/components/common/Row/Row.module.css
@@ -1,0 +1,4 @@
+.wrapper {
+  margin-left: 20px;
+  min-width: 420px;
+}

--- a/src/components/common/Row/Row.tsx
+++ b/src/components/common/Row/Row.tsx
@@ -1,0 +1,42 @@
+import { Box, BoxProps, Group, Text } from "@mantine/core";
+import classes from "./Row.module.css";
+
+export interface RowProps extends BoxProps {
+  field?: string; // 필드 이름
+  children: React.ReactNode;
+  fieldSize?: "sm" | "md" | "lg" | "xl" | number; // 필드 부분이 차지하는 길이
+  flexStart?: boolean;
+}
+
+export function Row({
+  field = "",
+  fieldSize = "md",
+  children,
+  flexStart = false,
+  ...props
+}: RowProps) {
+  return (
+    <Box className={classes.wrapper} {...props}>
+      <Group gap={0} wrap="nowrap" align={flexStart ? "flex-start" : undefined}>
+        <Text
+          style={{
+            minWidth:
+              fieldSize === "sm"
+                ? 60
+                : fieldSize === "md"
+                  ? 100
+                  : fieldSize === "lg"
+                    ? 200
+                    : fieldSize === "xl"
+                      ? 300
+                      : fieldSize,
+          }}
+          fz={16}
+        >
+          {field}
+        </Text>
+        {children}
+      </Group>
+    </Box>
+  );
+}

--- a/src/components/common/Row/index.ts
+++ b/src/components/common/Row/index.ts
@@ -1,0 +1,1 @@
+export { Row } from "./Row";

--- a/src/components/common/Section/Section.module.css
+++ b/src/components/common/Section/Section.module.css
@@ -1,0 +1,6 @@
+.wrapper {
+  width: 100%;
+  border-radius: 20px;
+  background: var(--mantine-color-white);
+  padding: 20px;
+}

--- a/src/components/common/Section/Section.tsx
+++ b/src/components/common/Section/Section.tsx
@@ -1,0 +1,14 @@
+import { Box, BoxProps } from "@mantine/core";
+import classes from "./Section.module.css";
+
+interface Props extends BoxProps {
+  children: React.ReactNode;
+}
+
+export function Section({ children, ...props }: Props) {
+  return (
+    <Box component="section" className={classes.wrapper} {...props}>
+      {children}
+    </Box>
+  );
+}

--- a/src/components/common/Section/index.ts
+++ b/src/components/common/Section/index.ts
@@ -1,0 +1,1 @@
+export { Section } from "./Section";


### PR DESCRIPTION
작성자: @hynseok

## 체크 리스트

- [x] 적절한 제목으로 수정했나요?
- [x] 상단에 이슈 번호를 기입했나요?
- [x] Target Branch를 올바르게 설정했나요?
- [x] Label을 알맞게 설정했나요?

## 작업 내역

- 페이지 제목 (PageHeader)
- 흰색 바탕의 박스 (Section)
- (필드값 - 텍스트인풋등) 의 쌍으로 이루어진 행 (Row)
컴포넌트를 추가하였습니다.

## 비고
