### PR TITLE
[Feat] 관리자 공지사항 목록조회 페이지 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@tabler/icons-react": "^3.11.0",
         "@types/js-cookie": "^3.0.6",
         "axios": "^1.7.3",
+        "classnames": "^2.5.1",
         "js-cookie": "^3.0.5",
         "jwt-decode": "^4.0.0",
         "next": "14.2.4",
@@ -8140,6 +8141,11 @@
       "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.3.1.tgz",
       "integrity": "sha512-a3KdPAANPbNE4ZUv9h6LckSl9zLsYOP4MBmhIPkRaeyybt+r4UghLvq+xw/YwUcC1gqylCkL4rdVs3Lwupjm4Q==",
       "dev": true
+    },
+    "node_modules/classnames": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
+      "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow=="
     },
     "node_modules/clean-css": {
       "version": "5.3.3",
@@ -23848,6 +23854,11 @@
         }
       }
     },
+    "@types/js-cookie": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/js-cookie/-/js-cookie-3.0.6.tgz",
+      "integrity": "sha512-wkw9yd1kEXOPnvEeEV1Go1MmxtBJL0RR79aOTAApecWFVu7w0NNXNqhcWgvw2YgZDYadliXkl14pa3WXw5jlCQ=="
+    },
     "@types/jsdom": {
       "version": "20.0.1",
       "resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-20.0.1.tgz",
@@ -24798,8 +24809,7 @@
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "dev": true
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "available-typed-arrays": {
       "version": "1.0.7",
@@ -24815,6 +24825,16 @@
       "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.9.1.tgz",
       "integrity": "sha512-QbUdXJVTpvUTHU7871ppZkdOLBeGUKBQWHkHrvN2V9IQWGMt61zf3B45BtzjxEJzYuj0JBjBZP/hmYS/R9pmAw==",
       "dev": true
+    },
+    "axios": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.3.tgz",
+      "integrity": "sha512-Ar7ND9pU99eJ9GpoGQKhKf58GpUOgnzuaB7ueNQ5BMi0p+LZ5oaEnfF999fAArcTIBwXTCHAmGcHOZJaWPq9Nw==",
+      "requires": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
     },
     "axobject-query": {
       "version": "3.1.1",
@@ -25552,6 +25572,11 @@
       "integrity": "sha512-a3KdPAANPbNE4ZUv9h6LckSl9zLsYOP4MBmhIPkRaeyybt+r4UghLvq+xw/YwUcC1gqylCkL4rdVs3Lwupjm4Q==",
       "dev": true
     },
+    "classnames": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
+      "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow=="
+    },
     "clean-css": {
       "version": "5.3.3",
       "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-5.3.3.tgz",
@@ -25766,7 +25791,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "requires": {
         "delayed-stream": "~1.0.0"
       }
@@ -26237,8 +26261,7 @@
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "dev": true
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
     },
     "depd": {
       "version": "2.0.0",
@@ -27652,6 +27675,11 @@
       "integrity": "sha512-topOrETNxJ6T2gAnQiWqAlzGPj8uI2wtmNOlDIMNB+qyvGJZ6R++STbUOTAYmvPhOMz2gXnXPH0hOvURYmrBow==",
       "dev": true
     },
+    "follow-redirects": {
+      "version": "1.15.6",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
+      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA=="
+    },
     "for-each": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
@@ -27719,7 +27747,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
       "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-      "dev": true,
       "requires": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -29650,6 +29677,11 @@
       "integrity": "sha512-2yTgeWTWzMWkHu6Jp9NKgePDaYHbntiwvYuuJLbbN9vl7DC9DvXKOB2BC3ZZ92D3cvV/aflH0osDfwpHepQ53w==",
       "dev": true
     },
+    "js-cookie": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.5.tgz",
+      "integrity": "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw=="
+    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -29784,6 +29816,11 @@
         "object.assign": "^4.1.4",
         "object.values": "^1.1.6"
       }
+    },
+    "jwt-decode": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-4.0.0.tgz",
+      "integrity": "sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA=="
     },
     "keyv": {
       "version": "4.5.4",
@@ -30271,14 +30308,12 @@
     "mime-db": {
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "dev": true
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="
     },
     "mime-types": {
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dev": true,
       "requires": {
         "mime-db": "1.52.0"
       }
@@ -31304,6 +31339,11 @@
         "forwarded": "0.2.0",
         "ipaddr.js": "1.9.1"
       }
+    },
+    "proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "psl": {
       "version": "1.9.0",
@@ -32823,6 +32863,15 @@
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="
     },
+    "swr": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-2.2.5.tgz",
+      "integrity": "sha512-QtxqyclFeAsxEUeZIYmsaQ0UjimSq1RZ9Un7I68/0ClKK/U3LoyQunwkQfJZr2fc22DfIXLNDc2wFyTEikCUpg==",
+      "requires": {
+        "client-only": "^0.0.1",
+        "use-sync-external-store": "^1.2.0"
+      }
+    },
     "symbol-tree": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
@@ -33550,6 +33599,12 @@
         "detect-node-es": "^1.1.0",
         "tslib": "^2.0.0"
       }
+    },
+    "use-sync-external-store": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.2.tgz",
+      "integrity": "sha512-PElTlVMwpblvbNqQ82d2n6RjStvdSoNe9FG28kNfz3WiXilJm4DdNkEzRhCZuIDwY8U08WVihhGR5iRqAwfDiw==",
+      "requires": {}
     },
     "util": {
       "version": "0.12.5",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "axios": "^1.7.3",
     "js-cookie": "^3.0.5",
     "jwt-decode": "^4.0.0",
+    "classnames": "^2.5.1",
     "next": "14.2.4",
     "react": "^18",
     "react-dom": "^18",

--- a/src/app/(admin)/admin/(boards)/notices/page.tsx
+++ b/src/app/(admin)/admin/(boards)/notices/page.tsx
@@ -1,3 +1,11 @@
+import { PageHeader } from "@/components/common/PageHeader";
+import { AdminNoticeListSection } from "@/components/pages/AdminNoticeListSection";
+
 export default function AdminNoticesPage() {
-  return <main>Hello, world!</main>;
+  return (
+    <main>
+      <PageHeader title={"공지사항 게시판 관리"} />
+      <AdminNoticeListSection />
+    </main>
+  );
 }

--- a/src/components/common/Buttons/DangerButton/DangerButton.story.tsx
+++ b/src/components/common/Buttons/DangerButton/DangerButton.story.tsx
@@ -23,6 +23,6 @@ type Story = StoryObj<typeof meta>;
 // More on writing stories with args: https://storybook.js.org/docs/writing-stories/args
 export const Usage: Story = {
   args: {
-    label: "Button",
+    children: "Button",
   },
 };

--- a/src/components/common/Buttons/DangerButton/DangerButton.test.tsx
+++ b/src/components/common/Buttons/DangerButton/DangerButton.test.tsx
@@ -4,7 +4,7 @@ import "@testing-library/jest-dom";
 
 describe("DangerButton component", () => {
   it("renders correctly with the given label", () => {
-    render(<DangerButton label="Button" />);
+    render(<DangerButton>Button</DangerButton>);
     // More on screen queries: https://testing-library.com/docs/queries/about
     // More on jest expect Api: https://jestjs.io/docs/expect
     expect(screen.getByRole("button", { name: "Button" })).toBeInTheDocument();

--- a/src/components/common/Buttons/DangerButton/DangerButton.tsx
+++ b/src/components/common/Buttons/DangerButton/DangerButton.tsx
@@ -1,11 +1,16 @@
 import { Button, ButtonProps } from "@mantine/core";
+import classNames from "classnames";
 import classes from "./DangerButton.module.css";
 
-export function DangerButton({ label, ...props }: ButtonProps & { label?: string }) {
+export function DangerButton({
+  children,
+  className,
+  ...props
+}: ButtonProps & React.ButtonHTMLAttributes<HTMLButtonElement>) {
   return (
     <>
-      <Button className={classes.element} {...props}>
-        {label}
+      <Button className={classNames(classes.element, className)} {...props}>
+        {children}
       </Button>
     </>
   );

--- a/src/components/common/Buttons/OutlinedButton/OutlinedButton.story.tsx
+++ b/src/components/common/Buttons/OutlinedButton/OutlinedButton.story.tsx
@@ -23,6 +23,6 @@ type Story = StoryObj<typeof meta>;
 // More on writing stories with args: https://storybook.js.org/docs/writing-stories/args
 export const Usage: Story = {
   args: {
-    label: "Button",
+    children: "Button",
   },
 };

--- a/src/components/common/Buttons/OutlinedButton/OutlinedButton.test.tsx
+++ b/src/components/common/Buttons/OutlinedButton/OutlinedButton.test.tsx
@@ -4,7 +4,7 @@ import "@testing-library/jest-dom";
 
 describe("OutlinedButton component", () => {
   it("renders correctly with the given label", () => {
-    render(<OutlinedButton label="Button" />);
+    render(<OutlinedButton>Button</OutlinedButton>);
     // More on screen queries: https://testing-library.com/docs/queries/about
     // More on jest expect Api: https://jestjs.io/docs/expect
     expect(screen.getByRole("button", { name: "Button" })).toBeInTheDocument();

--- a/src/components/common/Buttons/OutlinedButton/OutlinedButton.tsx
+++ b/src/components/common/Buttons/OutlinedButton/OutlinedButton.tsx
@@ -1,11 +1,16 @@
 import { Button, ButtonProps } from "@mantine/core";
+import classNames from "classnames";
 import classes from "./OutlinedButton.module.css";
 
-export function OutlinedButton({ label, ...props }: ButtonProps & { label?: string }) {
+export function OutlinedButton({
+  children,
+  className,
+  ...props
+}: ButtonProps & React.ButtonHTMLAttributes<HTMLButtonElement>) {
   return (
     <>
-      <Button className={classes.element} {...props}>
-        {label}
+      <Button className={classNames(classes.element, className)} {...props}>
+        {children}
       </Button>
     </>
   );

--- a/src/components/common/Buttons/PrimaryButton/PrimaryButton.story.tsx
+++ b/src/components/common/Buttons/PrimaryButton/PrimaryButton.story.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import { PrimaryButton } from "./PrimaryButton";
+import { IconThumbUp } from "@tabler/icons-react";
 
 // More on how to set up stories at: https://storybook.js.org/docs/writing-stories#default-export
 const meta = {
@@ -23,13 +24,24 @@ type Story = StoryObj<typeof meta>;
 // More on writing stories with args: https://storybook.js.org/docs/writing-stories/args
 export const Usage: Story = {
   args: {
-    label: "Button",
+    children: "Button",
   },
 };
 
 export const Disabled: Story = {
   args: {
-    label: "Button",
+    children: "Button",
     disabled: true,
+  },
+};
+
+export const WithIcon: Story = {
+  args: {
+    children: (
+      <>
+        <IconThumbUp size={18} />
+        Button
+      </>
+    ),
   },
 };

--- a/src/components/common/Buttons/PrimaryButton/PrimaryButton.test.tsx
+++ b/src/components/common/Buttons/PrimaryButton/PrimaryButton.test.tsx
@@ -4,9 +4,16 @@ import "@testing-library/jest-dom";
 
 describe("PrimaryButton component", () => {
   it("renders correctly with the given label", () => {
-    render(<PrimaryButton label="Button" />);
+    render(<PrimaryButton>Button</PrimaryButton>);
     // More on screen queries: https://testing-library.com/docs/queries/about
     // More on jest expect Api: https://jestjs.io/docs/expect
     expect(screen.getByRole("button", { name: "Button" })).toBeInTheDocument();
+  });
+
+  it("applies the given className", () => {
+    const testClassName = "test-class";
+    render(<PrimaryButton className={testClassName}>Button</PrimaryButton>);
+
+    expect(screen.getByRole("button", { name: "Button" })).toHaveClass(testClassName);
   });
 });

--- a/src/components/common/Buttons/PrimaryButton/PrimaryButton.tsx
+++ b/src/components/common/Buttons/PrimaryButton/PrimaryButton.tsx
@@ -1,12 +1,15 @@
 import { Button, ButtonProps } from "@mantine/core";
+import classNames from "classnames";
 import classes from "./PrimaryButton.module.css";
 
-export function PrimaryButton({ label, ...props }: ButtonProps & { label?: string }) {
+export function PrimaryButton({
+  children,
+  className,
+  ...props
+}: ButtonProps & React.ButtonHTMLAttributes<HTMLButtonElement>) {
   return (
-    <>
-      <Button className={classes.element} {...props}>
-        {label}
-      </Button>
-    </>
+    <Button className={classNames(classes.element, className)} {...props}>
+      {children}
+    </Button>
   );
 }

--- a/src/components/common/Buttons/SecondaryButton/SecondaryButton.story.tsx
+++ b/src/components/common/Buttons/SecondaryButton/SecondaryButton.story.tsx
@@ -23,13 +23,13 @@ type Story = StoryObj<typeof meta>;
 // More on writing stories with args: https://storybook.js.org/docs/writing-stories/args
 export const Usage: Story = {
   args: {
-    label: "Button",
+    children: "Button",
   },
 };
 
 export const Disabled: Story = {
   args: {
-    label: "Button",
+    children: "Button",
     disabled: true,
   },
 };

--- a/src/components/common/Buttons/SecondaryButton/SecondaryButton.test.tsx
+++ b/src/components/common/Buttons/SecondaryButton/SecondaryButton.test.tsx
@@ -4,7 +4,7 @@ import "@testing-library/jest-dom";
 
 describe("SecondaryButton component", () => {
   it("renders correctly with the given label", () => {
-    render(<SecondaryButton label="Button" />);
+    render(<SecondaryButton>Button</SecondaryButton>);
     // More on screen queries: https://testing-library.com/docs/queries/about
     // More on jest expect Api: https://jestjs.io/docs/expect
     expect(screen.getByRole("button", { name: "Button" })).toBeInTheDocument();

--- a/src/components/common/Buttons/SecondaryButton/SecondaryButton.tsx
+++ b/src/components/common/Buttons/SecondaryButton/SecondaryButton.tsx
@@ -1,11 +1,16 @@
 import { Button, ButtonProps } from "@mantine/core";
+import classNames from "classnames";
 import classes from "./SecondaryButton.module.css";
 
-export function SecondaryButton({ label, ...props }: ButtonProps & { label?: string }) {
+export function SecondaryButton({
+  children,
+  className,
+  ...props
+}: ButtonProps & React.ButtonHTMLAttributes<HTMLButtonElement>) {
   return (
     <>
-      <Button className={classes.element} {...props}>
-        {label}
+      <Button className={classNames(classes.element, className)} {...props}>
+        {children}
       </Button>
     </>
   );

--- a/src/components/common/DataTable/DataTable.module.css
+++ b/src/components/common/DataTable/DataTable.module.css
@@ -19,3 +19,14 @@
     border-color: var(--color-outlineVariant);
   }
 }
+
+.pagination-control {
+  border: none;
+  background-color: transparent;
+
+  font-weight: 500;
+  --pagination-active-color: var(--color-primary);
+  &:hover {
+    background-color: var(--color-outlineVariant);
+  }
+}

--- a/src/components/common/DataTable/DataTable.tsx
+++ b/src/components/common/DataTable/DataTable.tsx
@@ -7,6 +7,9 @@ import {
   TableCaption as DataTableFooterContainer,
   Group,
   Select,
+  Pagination,
+  Checkbox,
+  TableTh,
 } from "@mantine/core";
 import { DataTableHeader, DataTableHeaderProps } from "./elements/DataTableHeader";
 import { Dispatch, ReactNode, SetStateAction } from "react";
@@ -18,23 +21,39 @@ import { PAGE_SIZES } from "@/constants/PageSize";
 export interface DataTableProps extends TableProps {
   headers: DataTableHeaderProps[];
   children: ReactNode;
+  withCheckbox?: boolean;
+  checkboxProps?: {
+    checked: boolean;
+    indeterminate: boolean;
+    onChange: () => void;
+  };
   sortBy?: string;
   order?: string;
   handleSortButton?: (selector?: string) => void;
-  totalSize?: string;
+
+  totalElements?: string;
   pageSize?: string | null;
   setPageSize?: Dispatch<SetStateAction<string | null>>;
+
+  totalPages?: number;
+  pageNumber?: number;
+  setPageNumber?: Dispatch<SetStateAction<number>>;
 }
 
 export function DataTable({
   headers,
   children,
+  withCheckbox,
+  checkboxProps,
   sortBy,
   order,
   handleSortButton,
-  totalSize,
+  totalElements,
   pageSize,
   setPageSize,
+  totalPages,
+  pageNumber,
+  setPageNumber,
   ...props
 }: DataTableProps) {
   return (
@@ -42,6 +61,15 @@ export function DataTable({
       <DataTableContainer horizontalSpacing="lg" className={classes.container} {...props}>
         <DataTableHeaderContainer className={classes.header}>
           <TableRow className={classes["header-row"]}>
+            {withCheckbox && (
+              <TableTh style={{ width: "1%", borderTopLeftRadius: "10px" }}>
+                <Checkbox
+                  checked={checkboxProps?.checked}
+                  indeterminate={checkboxProps?.indeterminate}
+                  onChange={checkboxProps?.onChange}
+                />
+              </TableTh>
+            )}
             {headers.map((header, index) => (
               <DataTableHeader
                 key={index}
@@ -58,9 +86,9 @@ export function DataTable({
         </DataTableHeaderContainer>
         <DataTableBody>{children}</DataTableBody>
         <DataTableFooterContainer>
-          <Group>
-            <div>전체 {totalSize}개</div>
+          <Group justify="space-between">
             <Group gap={4}>
+              <div>전체 {totalElements}개</div>
               <Select
                 h={40}
                 w={80}
@@ -76,7 +104,14 @@ export function DataTable({
               />
               <div>개씩 보기</div>
             </Group>
-            {/* TODO: Pagenation 추가 */}
+            {pageNumber && setPageNumber && totalPages && (
+              <Pagination
+                value={pageNumber}
+                onChange={setPageNumber}
+                total={totalPages}
+                classNames={{ control: classes["pagination-control"] }}
+              />
+            )}
           </Group>
         </DataTableFooterContainer>
       </DataTableContainer>

--- a/src/components/common/DataTable/DataTableUsage.tsx
+++ b/src/components/common/DataTable/DataTableUsage.tsx
@@ -53,7 +53,7 @@ export function DataTableUsage() {
       order={order}
       handleSortButton={handleSortButton}
       w={900}
-      totalSize={total}
+      totalElements={total}
       pageSize={pageSize}
       setPageSize={setPageSize}
     >

--- a/src/components/common/DataTable/elements/DataTableData.module.css
+++ b/src/components/common/DataTable/elements/DataTableData.module.css
@@ -2,7 +2,7 @@
   height: 58px;
   word-break: break-all;
   background-color: transparent;
-  border-bottom: 8px solid var(--color-surfaceContainerLowest);
+  border-bottom: 8px solid var(--color-surface);
 }
 
 .block {

--- a/src/components/common/DataTable/elements/DataTableData.tsx
+++ b/src/components/common/DataTable/elements/DataTableData.tsx
@@ -4,15 +4,20 @@ import classes from "./DataTableData.module.css";
 
 interface DataTableDataProps {
   maxWidth?: string;
+  text?: boolean;
   children: ReactNode;
 }
 
-export function DataTableData({ maxWidth, children }: DataTableDataProps) {
+export function DataTableData({ maxWidth, text = true, children }: DataTableDataProps) {
   return (
     <DataTableDataElement fz={16} fw={500} className={classes.element}>
-      <p style={{ maxWidth: maxWidth }} className={classes.block}>
-        {children}
-      </p>
+      {text ? (
+        <p style={{ maxWidth: maxWidth }} className={classes.block}>
+          {children}
+        </p>
+      ) : (
+        children
+      )}
     </DataTableDataElement>
   );
 }

--- a/src/components/common/DataTable/elements/DataTableRow.module.css
+++ b/src/components/common/DataTable/elements/DataTableRow.module.css
@@ -9,5 +9,6 @@
 }
 
 .containerNoPointer {
+  background-color: var(--color-tableRow);
   height: 56px;
 }

--- a/src/components/common/SearchInput/SearchInput.tsx
+++ b/src/components/common/SearchInput/SearchInput.tsx
@@ -4,11 +4,21 @@ import { IconSearch } from "@tabler/icons-react";
 export function SearchInput({
   placeholder,
   iconSize = 16,
+  onChange,
   ...props
-}: InputProps & { placeholder?: string; iconSize?: number }) {
+}: InputProps & {
+  placeholder?: string;
+  iconSize?: number;
+  onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void;
+}) {
   return (
     <>
-      <Input placeholder={placeholder} leftSection={<IconSearch size={iconSize} />} {...props} />
+      <Input
+        placeholder={placeholder}
+        leftSection={<IconSearch size={iconSize} />}
+        onChange={onChange}
+        {...props}
+      />
     </>
   );
 }

--- a/src/components/common/TextInput/TextInput.tsx
+++ b/src/components/common/TextInput/TextInput.tsx
@@ -6,6 +6,7 @@ type TextInputPropsType = {
   description?: string | ReactNode;
   error?: string | ReactNode;
   placeholder?: string;
+  onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void;
 };
 
 export function TextInput({
@@ -13,11 +14,12 @@ export function TextInput({
   description,
   error,
   placeholder,
+  onChange,
   ...props
 }: InputProps & TextInputPropsType) {
   return (
     <InputWrapper label={label} description={description} error={error}>
-      <Input placeholder={placeholder} {...props} />
+      <Input placeholder={placeholder} onChange={onChange} {...props} />
     </InputWrapper>
   );
 }

--- a/src/components/pages/AdminNoticeListSection/AdminNoticeListSection.tsx
+++ b/src/components/pages/AdminNoticeListSection/AdminNoticeListSection.tsx
@@ -1,0 +1,145 @@
+/* eslint-disable @typescript-eslint/ban-ts-comment */
+// @eslint-ignore
+// @prettier-ignore
+
+"use client";
+
+import { DangerButton, PrimaryButton } from "@/components/common/Buttons";
+import { DataTable } from "@/components/common/DataTable";
+import { DataTableData } from "@/components/common/DataTable/elements/DataTableData";
+import { DataTableRow } from "@/components/common/DataTable/elements/DataTableRow";
+import { SearchInput } from "@/components/common/SearchInput";
+import { NOTICE_TABLE_HEADERS } from "@/constants/DataTableHeaders";
+import { PAGE_SIZES, REFRESH_DEFAULT_PAGE_NUMBER } from "@/constants/PageSize";
+import { useNotices } from "@/hooks/swr/useNotices";
+import { useTableSort } from "@/hooks/useTableSort";
+import { PagedNoticesRequestParams } from "@/types/notice";
+import { CommonAxios } from "@/utils/CommonAxios";
+import { handleChangeSearch } from "@/utils/handleChangeSearch";
+// import { getSortString } from "@/utils/getSortString";
+import { Button, Checkbox, Group, Stack } from "@mantine/core";
+import { useDebouncedState } from "@mantine/hooks";
+import { useRouter } from "next/navigation";
+import { ChangeEvent, useEffect, useState } from "react";
+
+export function AdminNoticeListSection() {
+  /* next 라우터, 페이지 이동에 이용 */
+  const { push } = useRouter();
+
+  /* 페이지당 행 개수 */
+  const [pageSize, setPageSize] = useState<string | null>(String(PAGE_SIZES[0]));
+  /* 페이지네이션 페이지 넘버*/
+  const [pageNumber, setPageNumber] = useState(1);
+  /* 데이터 정렬 훅 */
+  const { sortBy, order, handleSortButton } = useTableSort();
+  /* 쿼리 debounced state */
+  const [query, setQuery] = useDebouncedState<PagedNoticesRequestParams>(
+    {
+      page: pageNumber - 1,
+      size: Number(pageSize),
+    },
+    300
+  );
+
+  /* SWR 훅을 사용하여 공지사항 목록 패칭 */
+  const { data, pageData, mutate } = useNotices({
+    params: { ...query, page: pageNumber - 1, size: Number(pageSize) },
+  });
+
+  /* 체크박스 전체선택, 일괄선택 다루는 파트 */
+  const [selectedNotices, setSelectedNotices] = useState<number[]>([]);
+  const allChecked = selectedNotices.length === data?.length;
+  const indeterminate = selectedNotices.length > 0 && !allChecked;
+  // 전체선택 함수
+  const handleSelectAll = () => {
+    if (data) {
+      if (allChecked) {
+        setSelectedNotices([]);
+      } else {
+        setSelectedNotices(data.map((notice) => notice.id));
+      }
+    }
+  };
+  // 개별선택 함수
+  const handleSelect = (id: number) => {
+    console.log(data);
+    console.log(pageData);
+    setSelectedNotices((prev) =>
+      prev.includes(id) ? prev.filter((noticeId) => noticeId !== id) : [...prev, id]
+    );
+  };
+
+  /* 검색창 핸들러 */
+  const onSearchChange = (event: ChangeEvent<HTMLInputElement>) => {
+    handleChangeSearch<string, PagedNoticesRequestParams>({
+      name: "title",
+      value: event.target.value,
+      setQuery,
+    });
+  };
+
+  /* 삭제 버튼 핸들러 */
+  const handleDelete = () => {
+    // TODO: 삭제 확인하는 모달 추가
+    Promise.all(selectedNotices.map((id) => CommonAxios.delete(`/notices/${id}`))).then(() => {
+      setSelectedNotices([]);
+      mutate();
+    });
+  };
+
+  useEffect(() => {
+    setPageNumber(REFRESH_DEFAULT_PAGE_NUMBER);
+  }, [pageSize]);
+
+  return (
+    <>
+      <Stack>
+        <Group justify="flex-end">
+          <SearchInput placeholder="제목 입력" w={300} onChange={onSearchChange} />
+        </Group>
+        <Group justify="space-between">
+          {/* @ts-ignore */}
+          <DangerButton label="선택 삭제" onClick={handleDelete} />
+          <PrimaryButton
+            label="게시글 등록"
+            /* @ts-ignore */
+            onClick={() => {
+              push("notices/create");
+            }}
+          />
+        </Group>
+        <DataTable
+          headers={NOTICE_TABLE_HEADERS}
+          sortBy={sortBy}
+          order={order}
+          handleSortButton={handleSortButton}
+          totalElements={String(pageData?.totalElements)}
+          pageSize={pageSize}
+          setPageSize={setPageSize}
+          totalPages={pageData?.totalPages}
+          pageNumber={pageNumber}
+          setPageNumber={setPageNumber}
+          withCheckbox
+          checkboxProps={{ checked: allChecked, indeterminate, onChange: handleSelectAll }}
+        >
+          {data?.map((notice, index) => (
+            <DataTableRow key={index}>
+              <DataTableData text={false}>
+                <Checkbox
+                  checked={selectedNotices.includes(notice.id)}
+                  onChange={() => handleSelect(notice.id)}
+                />
+              </DataTableData>
+              <DataTableData>{index + 1 + (pageNumber - 1) * Number(pageSize)}</DataTableData>
+              <DataTableData>{notice.title}</DataTableData>
+              <DataTableData>{notice.createdAt}</DataTableData>
+              <DataTableData text={false}>
+                <Button>수정</Button>
+              </DataTableData>
+            </DataTableRow>
+          ))}
+        </DataTable>
+      </Stack>
+    </>
+  );
+}

--- a/src/components/pages/AdminNoticeListSection/AdminNoticeListSection.tsx
+++ b/src/components/pages/AdminNoticeListSection/AdminNoticeListSection.tsx
@@ -1,7 +1,3 @@
-/* eslint-disable @typescript-eslint/ban-ts-comment */
-// @eslint-ignore
-// @prettier-ignore
-
 "use client";
 
 import { DangerButton, PrimaryButton } from "@/components/common/Buttons";
@@ -98,15 +94,14 @@ export function AdminNoticeListSection() {
           <SearchInput placeholder="제목 입력" w={300} onChange={onSearchChange} />
         </Group>
         <Group justify="space-between">
-          {/* @ts-ignore */}
-          <DangerButton label="선택 삭제" onClick={handleDelete} />
+          <DangerButton onClick={handleDelete}>선택 삭제</DangerButton>
           <PrimaryButton
-            label="게시글 등록"
-            /* @ts-ignore */
             onClick={() => {
               push("notices/create");
             }}
-          />
+          >
+            게시글 등록
+          </PrimaryButton>
         </Group>
         <DataTable
           headers={NOTICE_TABLE_HEADERS}

--- a/src/components/pages/AdminNoticeListSection/index.ts
+++ b/src/components/pages/AdminNoticeListSection/index.ts
@@ -1,0 +1,1 @@
+export { AdminNoticeListSection } from "./AdminNoticeListSection";

--- a/src/constants/DataTableHeaders.ts
+++ b/src/constants/DataTableHeaders.ts
@@ -8,3 +8,10 @@ export const MOCK_TABLE_HEADERS: DataTableHeaderProps[] = [
   { label: "권한", widthPercentage: 7, sort: true, selector: "role" },
   { label: "가입일시", widthPercentage: 15, sort: true, selector: "createdAt" },
 ];
+
+export const NOTICE_TABLE_HEADERS: DataTableHeaderProps[] = [
+  { label: "순번", widthPercentage: 7, sort: true, selector: "num" },
+  { label: "제목", widthPercentage: 20, sort: true, selector: "title" },
+  { label: "작성일", widthPercentage: 10, sort: false, selector: "createdAt" },
+  { label: "관리", widthPercentage: 7, sort: false, selector: "updatedAt" },
+];

--- a/src/constants/DataTableHeaders.ts
+++ b/src/constants/DataTableHeaders.ts
@@ -10,8 +10,8 @@ export const MOCK_TABLE_HEADERS: DataTableHeaderProps[] = [
 ];
 
 export const NOTICE_TABLE_HEADERS: DataTableHeaderProps[] = [
-  { label: "순번", widthPercentage: 7, sort: true, selector: "num" },
+  { label: "순번", widthPercentage: 7, sort: true, selector: "id" },
   { label: "제목", widthPercentage: 20, sort: true, selector: "title" },
-  { label: "작성일", widthPercentage: 10, sort: false, selector: "createdAt" },
-  { label: "관리", widthPercentage: 7, sort: false, selector: "updatedAt" },
+  { label: "작성일", widthPercentage: 10, sort: true, selector: "createdAt" },
+  { label: "관리", widthPercentage: 7, sort: false },
 ];

--- a/src/constants/PageSize.ts
+++ b/src/constants/PageSize.ts
@@ -2,3 +2,4 @@ export const PAGE_SIZES = [10, 25, 50, 100];
 export const PAGE_SIZE_GET_ALL = 1000;
 export const PAGE_NUMBER_GET_ALL = 1;
 export const PAGE_SIZE_DEFAULT = 10;
+export const REFRESH_DEFAULT_PAGE_NUMBER = 1;

--- a/src/constants/PageSize.ts
+++ b/src/constants/PageSize.ts
@@ -1,1 +1,4 @@
 export const PAGE_SIZES = [10, 25, 50, 100];
+export const PAGE_SIZE_GET_ALL = 1000;
+export const PAGE_NUMBER_GET_ALL = 1;
+export const PAGE_SIZE_DEFAULT = 10;

--- a/src/hooks/swr/useNotices.tsx
+++ b/src/hooks/swr/useNotices.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { PagedNoticesRequestParams, PagedNoticesResponse } from "@/types/notice";
+import useSWR from "swr";
+
+export function useNotices({ params }: { params: PagedNoticesRequestParams }) {
+  const result = useSWR<PagedNoticesResponse>({ url: "/notices", query: params });
+
+  return {
+    data: result.data?.content,
+    pageData: result.data && {
+      pageSize: result.data.size,
+      pageNumber: result.data.number,
+      totalElements: result.data.totalElements,
+      totalPages: result.data.totalPages,
+    },
+    get isLoading() {
+      return result.isLoading;
+    },
+    get error() {
+      return result.error;
+    },
+    get mutate() {
+      return result.mutate;
+    },
+  };
+}

--- a/src/theme/AppTheme.ts
+++ b/src/theme/AppTheme.ts
@@ -129,6 +129,7 @@ export const AppTheme = createTheme({
       surfaceContainer: "#1D2024",
       surfaceContainerHigh: "#272A2F",
       surfaceContainerHighest: "#32353A",
+      tableRow: "#3E3E3E",
       inputBorder: "#424242",
       inputBorderFocus: "#228BE6",
       inputSurface: "#2E2E2E",

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -1,0 +1,32 @@
+export interface PagedApiResponse<T> {
+  totalElements: number;
+  totalPages: number;
+  size: number;
+  number: number;
+  numberOfElements: number;
+
+  first: boolean;
+  last: boolean;
+  empty: boolean;
+
+  content: T[];
+
+  sort: {
+    sorted: boolean;
+    unsorted: boolean;
+    empty: boolean;
+  };
+
+  pageable: {
+    pageNumber: number;
+    pageSize: number;
+    offset: number;
+    paged: boolean;
+    unpaged: boolean;
+    sort: {
+      sorted: boolean;
+      unsorted: boolean;
+      empty: boolean;
+    };
+  };
+}

--- a/src/types/notice.ts
+++ b/src/types/notice.ts
@@ -1,0 +1,20 @@
+import { PagedApiResponse } from "./common";
+
+export interface PagedNoticesRequestParams {
+  title?: string;
+  page?: number;
+  size?: number;
+  sort?: string;
+}
+
+export interface Notice {
+  id: number;
+  title: string;
+  hitCount: number;
+  fixed: boolean;
+  content: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface PagedNoticesResponse extends PagedApiResponse<Notice> {}

--- a/src/utils/getSortString/getSortString.ts
+++ b/src/utils/getSortString/getSortString.ts
@@ -1,0 +1,9 @@
+/**
+ *
+ * @param sortBy 정렬할 필드값의 이름
+ * @param order 정렬 방향 (0: 오름차순, 1: 내림차순)
+ * @returns 정렬 문자열
+ */
+export function getSortString({ sortBy, order }: { sortBy: string; order: number }) {
+  return `${sortBy},${order === 0 ? "asc" : "desc"}`;
+}

--- a/src/utils/getSortString/getSortString.ts
+++ b/src/utils/getSortString/getSortString.ts
@@ -4,6 +4,6 @@
  * @param order 정렬 방향 (0: 오름차순, 1: 내림차순)
  * @returns 정렬 문자열
  */
-export function getSortString({ sortBy, order }: { sortBy: string; order: number }) {
+export function getSortString({ sortBy, order }: { sortBy?: string; order?: number }) {
   return `${sortBy},${order === 0 ? "asc" : "desc"}`;
 }

--- a/src/utils/getSortString/index.ts
+++ b/src/utils/getSortString/index.ts
@@ -1,0 +1,1 @@
+export { getSortString } from "./getSortString";

--- a/src/utils/handleChangeSearch/handleChangeSearch.tsx
+++ b/src/utils/handleChangeSearch/handleChangeSearch.tsx
@@ -1,0 +1,16 @@
+import { REFRESH_DEFAULT_PAGE_NUMBER } from "@/constants/PageSize";
+import { SetStateAction } from "react";
+
+export type ChangeQueryArg<T, U> = {
+  name: string;
+  value: T;
+  setQuery: (newValue: SetStateAction<U>) => void;
+};
+
+export const handleChangeSearch = <T, U>({ name, value, setQuery }: ChangeQueryArg<T, U>) => {
+  setQuery((prev) => ({
+    ...prev,
+    [name]: value === "" ? undefined : value,
+    pageNumber: REFRESH_DEFAULT_PAGE_NUMBER,
+  }));
+};

--- a/src/utils/handleChangeSearch/index.ts
+++ b/src/utils/handleChangeSearch/index.ts
@@ -1,0 +1,1 @@
+export { handleChangeSearch } from "./handleChangeSearch";


### PR DESCRIPTION
작성자: @hynseok 

## 체크 리스트

- [x] 적절한 제목으로 수정했나요?
- [x] 상단에 이슈 번호를 기입했나요?
- [x] Target Branch를 올바르게 설정했나요?
- [x] Label을 알맞게 설정했나요?

## 작업 내역

- 관리자 공지사항 목록조회 페이지를 추가
- 테이블 페이지네이션 및 체크박스 추가 (사용법은 AdminNoticeListSection 참고)
- search input, text input 컴포넌트 onChange props 추가 (cc. @chunzhi23)

## 비고

