### PR TITLE
작품 수상 결과 페이지 API 연결

### DIFF
--- a/src/components/common/ProjectCard/ProjectCard.tsx
+++ b/src/components/common/ProjectCard/ProjectCard.tsx
@@ -27,7 +27,7 @@ export function ProjectCard({
 }: ProjectCardProps) {
   const studentsString = data.studentNames.join(", ");
   const professorString = data.professorNames.join(", ");
-  
+
   return (
     <Card className={classes.card} w={width} h={height}>
       <CardSection className={classes["img-section"]}>

--- a/src/components/pages/EventAwardView/EventAwardView.tsx
+++ b/src/components/pages/EventAwardView/EventAwardView.tsx
@@ -6,28 +6,104 @@ import { useEffect, useState } from "react";
 import classes from "./EventAwardView.module.css";
 import { Text } from "@mantine/core";
 import { Carousel, CarouselSlide } from "@mantine/carousel";
-import {
-  years as mock_years,
-  awards as mock_awards,
-  projects as mock_projects,
-} from "./_mock/mock-awards";
+import { getYears } from "@/utils/getYears";
+import { CommonAxios } from "@/utils/CommonAxios";
+import { AWARD_TYPE_LOOKUP_TABLE } from "@/constants/LookupTables";
+import { IProjectContent } from "@/types/project";
+import { getFileUrlById } from "@/utils/handleDownloadFile";
 
 export function EventAwardView() {
-  const [years, setYears] = useState<string[]>([]);
   const [selectedYear, setSelectedYear] = useState<string>("");
+  const [projects, setProjects] = useState<IProjectContent[]>([]);
+  const [thumbnailUrls, setThumbnailUrls] = useState<string[]>([]);
 
+  const years = getYears();
+
+  /**
+   * 가장 최근 연도를 디폴트로 설정
+   */
   useEffect(() => {
-    /* TODO: 연도 목록 가져오기 */
-    setYears(mock_years);
-    if (mock_years.length > 0) {
-      // 가장 최근 연도를 디폴트로
-      setSelectedYear(mock_years[0]);
+    if (!selectedYear && years && years.length > 0) {
+      setSelectedYear(years[0]);
     }
-  }, []);
+  }, [years, selectedYear]);
 
+  /**
+   * 연도 바뀔 때마다 수상작 가져오기
+   */
   useEffect(() => {
-    /* TODO: 선택된 연도의 수상 결과 가져오기 */
+    const fetchAwards = async () => {
+      try {
+        const response = await CommonAxios.get(`projects/award?year=${selectedYear}`);
+        const projectDatas: IProjectContent[] = response.data?.content;
+        setProjects(projectDatas);
+        // thumbnail url 가져오기
+        const promises = projectDatas.map((data) => getFileUrlById(data.thumbnailInfo.id));
+        const urlResults = await Promise.all(promises);
+        setThumbnailUrls(urlResults);
+      } catch (error) {
+        console.error("Error fetching awards:", error);
+      } finally {
+      }
+    };
+    fetchAwards();
   }, [selectedYear]);
+
+  /**
+   * like 핸들러
+   */
+  const handleClickLike = async (idx: number) => {
+    const data = projects[idx];
+    try {
+      if (data.like) {
+        await CommonAxios.delete(`/projects/${data.id}/like`);
+        updateProjectLikeStatus(idx, false);
+      } else {
+        await CommonAxios.post(`/projects/${data.id}/like`);
+        updateProjectLikeStatus(idx, true);
+      }
+    } catch (error) {
+      console.error("Failed to toggle like:", error);
+    }
+  };
+
+  /**
+   * bookMark 핸들러
+   */
+  const handleClickBookMark = async (idx: number) => {
+    const data = projects[idx];
+    try {
+      if (data.bookMark) {
+        await CommonAxios.delete(`/projects/${data.id}/favorite`);
+        updateProjectBookMarkStatus(idx, false);
+      } else {
+        await CommonAxios.post(`/projects/${data.id}/favorite`);
+        updateProjectBookMarkStatus(idx, true);
+      }
+    } catch (error) {
+      console.error("Failed to toggle bookmark:", error);
+    }
+  };
+
+  /**
+   * 프로젝트 like 상태 업데이트
+   */
+  const updateProjectLikeStatus = (idx: number, likeStatus: boolean) => {
+    setProjects((prevProjects) =>
+      prevProjects.map((project, i) => (i === idx ? { ...project, like: likeStatus } : project))
+    );
+  };
+
+  /**
+   * 프로젝트 bookMark 상태 업데이트
+   */
+  const updateProjectBookMarkStatus = (idx: number, bookMarkStatus: boolean) => {
+    setProjects((prevProjects) =>
+      prevProjects.map((project, i) =>
+        i === idx ? { ...project, bookMark: bookMarkStatus } : project
+      )
+    );
+  };
 
   return (
     <div className={classes.container}>
@@ -39,17 +115,20 @@ export function EventAwardView() {
       ></Dropdown>
       <Text className={classes.subtitle}>{selectedYear}년도 수상 내역</Text>
       <Carousel dragFree slideGap="md" slideSize="20%" align="start" containScroll="trimSnaps">
-        {mock_projects.map((data, idx) => (
-          <CarouselSlide key={idx}>
-            <Text className={classes.awardType}>{mock_awards[idx]}</Text>
-            <ProjectCard
-              data={data}
-              thumbnailUrl={""}
-              onClickBookmark={() => {}}
-              onClickLike={() => {}}
-            />
-          </CarouselSlide>
-        ))}
+        {projects.map((data, idx) => {
+          const thumbnailUrl = thumbnailUrls[idx];
+          return (
+            <CarouselSlide key={idx}>
+              <Text className={classes.awardType}>{AWARD_TYPE_LOOKUP_TABLE[data.awardStatus]}</Text>
+              <ProjectCard
+                data={data}
+                thumbnailUrl={thumbnailUrl}
+                onClickLike={() => handleClickLike(idx)}
+                onClickBookmark={() => handleClickBookMark(idx)}
+              />
+            </CarouselSlide>
+          );
+        })}
       </Carousel>
     </div>
   );

--- a/src/constants/LookupTables.ts
+++ b/src/constants/LookupTables.ts
@@ -1,4 +1,5 @@
 import { Role } from "@/types/user";
+import { ProjectAwardStatus } from "@/types/project";
 
 export const USER_TYPE_LOOKUP_TABLE: Record<Role, string> = {
   STUDENT: "학생",
@@ -9,4 +10,13 @@ export const USER_TYPE_LOOKUP_TABLE: Record<Role, string> = {
   INACTIVE_COMPANY: "미승인 기업관계자",
   OTHERS: "기타",
   TEMP: "임시",
+};
+
+export const AWARD_TYPE_LOOKUP_TABLE: Record<ProjectAwardStatus, string> = {
+  NONE: "미정",
+  FIRST: "대상",
+  SECOND: "최우수상",
+  THIRD: "우수상",
+  FOURTH: "인기상",
+  FIFTH: "장려상",
 };

--- a/src/constants/UserNavigations.ts
+++ b/src/constants/UserNavigations.ts
@@ -58,12 +58,16 @@ export const USER_NAVS: INavList[] = [
     title: "Events",
     items: [
       {
-        name: "갤러리",
-        link: "/event/gallery",
-      },
-      {
         name: "이벤트 공지사항",
         link: "/event/notices",
+      },
+      {
+        name: "작품 수상 결과",
+        link: "/event/award",
+      },
+      {
+        name: "갤러리",
+        link: "/event/gallery",
       },
     ],
   },


### PR DESCRIPTION
작성자: @sera2002 
이슈: #41 

## 체크 리스트

- [x] 적절한 제목으로 수정했나요?
- [x] 상단에 이슈 번호를 기입했나요?
- [x] Target Branch를 올바르게 설정했나요?
- [x] Label을 알맞게 설정했나요?

## 작업 내역

- 작품 수상 결과 페이지 API 연결을 하였습니다.
- 내비게이션 바에서 Events의 하위 항목으로 "작품 수상 결과"를 추가하였습니다.

## 비고

- `AWARD_TYPE_LOOKUP_TABLE`에서 프로젝트 수상 status에 따라 상의 명칭을 임의로 설정해놓았는데, 정확한 명칭으로 변경해야 합니다.

close/resolve/fix #{이슈 번호 기입}
