### PR TITLE
[FIX] VideoCard 제목 text-overflow 처리

### DIFF
--- a/src/components/common/VideoCard/VideoCard.module.css
+++ b/src/components/common/VideoCard/VideoCard.module.css
@@ -33,6 +33,9 @@
   font-weight: 700;
   font-size: 20px;
   line-height: 24px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
   margin: 0;
 }
 


### PR DESCRIPTION
Issue: #133 
작성자: @chunzhi23 

## 체크 리스트

- [x] 적절한 제목으로 수정했나요?
- [x] 상단에 이슈 번호를 기입했나요?
- [x] Target Branch를 올바르게 설정했나요?
- [x] Label을 알맞게 설정했나요?

## 작업 내역

- 제목이 길어지면 text가 한 줄 내려오면서 videocard가 서로 다른 height를 가지게 되는데 넘어가는 부분을 `...`로 수정했습니다.