### PR TITLE
[FIX] 관리자 페이지 이벤트 기간 설정 안되는 문제 해결

### DIFF
--- a/src/components/pages/EventPeriodForm/EventPeriodForm.tsx
+++ b/src/components/pages/EventPeriodForm/EventPeriodForm.tsx
@@ -1,15 +1,15 @@
 "use client";
 
 import { PrimaryButton } from "@/components/common/Buttons";
-import { DateTimePicker } from "@mantine/dates";
 import { PageHeader } from "@/components/common/PageHeader";
-import { useState, useEffect } from "react";
 import { CommonAxios } from "@/utils/CommonAxios";
-import { Stack, Title, Group, Text } from "@mantine/core";
+import { Group, Stack, Text, Title } from "@mantine/core";
+import { DateTimePicker } from "@mantine/dates";
 import "@mantine/dates/styles.css";
 import dayjs from "dayjs";
-import utc from "dayjs/plugin/utc";
 import timezone from "dayjs/plugin/timezone";
+import utc from "dayjs/plugin/utc";
+import { useEffect, useState } from "react";
 dayjs.extend(utc);
 dayjs.extend(timezone);
 
@@ -49,12 +49,13 @@ export function EventPeriodForm() {
       .set("hour", startTime.getHours())
       .set("minute", startTime.getMinutes())
       .tz("Asia/Seoul")
-      .format();
+      .format("YYYY-MM-DDTHH:mm:ss"); // 수정: 타임존 오프셋 제거
+
     const end = dayjs(endDate)
       .set("hour", endTime.getHours())
       .set("minute", endTime.getMinutes())
       .tz("Asia/Seoul")
-      .format();
+      .format("YYYY-MM-DDTHH:mm:ss"); // 수정: 타임존 오프셋 제거
 
     try {
       await CommonAxios.post("/eventPeriods", { start, end });


### PR DESCRIPTION
작성자: @shj1081 

## 체크 리스트

- [x] 적절한 제목으로 수정했나요?
- [x] 상단에 이슈 번호를 기입했나요?
- [x] Target Branch를 올바르게 설정했나요?
- [x] Label을 알맞게 설정했나요?

## 작업 내역

- `EventPeriodForm.tsx`의 `handleChangePeriod` 함수에서 날짜 포맷을 BE의 요구사항과 동일하게 수정하였습니다.

## 비고

- 이벤트가 아무것도 없는 경우 제대로 설정이 되는 것을 확인하였습니다.
- 그런데 이벤트의 기간 변경의 경우, `EventPeriodForm.tsx` 의 코드를 보았을 때, 기존의 이벤트 기간을 업데이트 하는 BE 의 API를 사용하지 않아 두번째 이벤트를 설정하려 할때 기존의 이벤트 기간과 겹칠경우, BE의  `해당 연도의 행사 기간이 이미 존재합니다` 가 뜹니다
- BE의 eventPeriod 관련해서 `updateEventPeriod` 를 사용해야 해당 이벤트 기간을 변경 가능합니다.

> 용도가 이벤트 기간 수정이 아닌 단순 1회성 추가이기에 추가 코드 수정은 하지 않도록 하겠습니다.

