### PR TITLE
[FIX] 프로젝트 상세조회 페이지에서 inquiry 버튼 redirect url 수정, 비로그인 시 경고 메세지 절차 수행

### DIFF
--- a/src/components/pages/ProjectDetail/ProjectDetailInfo.tsx
+++ b/src/components/pages/ProjectDetail/ProjectDetailInfo.tsx
@@ -1,22 +1,22 @@
 "use client";
 
-import { useEffect, useState } from "react";
-import Image from "next/image";
-import { Flex, Text, AspectRatio, Button, Group, Stack, Divider } from "@mantine/core";
-import classes from "./ProjectDetailInfo.module.css";
-import { ProjectDetailDto, categoryMapping } from "./_type/project";
-import { CardBadge } from "@/components/common/CardBadge";
 import { PrimaryButton } from "@/components/common/Buttons";
+import { CardBadge } from "@/components/common/CardBadge";
+import { CommonAxios } from "@/utils/CommonAxios";
+import { getFileUrlById } from "@/utils/handleDownloadFile";
+import { AspectRatio, Button, Divider, Flex, Group, Stack, Text } from "@mantine/core";
 import {
-  IconThumbUp,
-  IconThumbUpFilled,
   IconBookmark,
   IconBookmarkFilled,
+  IconThumbUp,
+  IconThumbUpFilled,
 } from "@tabler/icons-react";
+import Image from "next/image";
 import { useRouter } from "next/navigation";
-import { CommonAxios } from "@/utils/CommonAxios";
+import { useEffect, useState } from "react";
 import { ProjectDetailComment } from "./ProjectDetailComment";
-import { getFileUrlById } from "@/utils/handleDownloadFile";
+import classes from "./ProjectDetailInfo.module.css";
+import { ProjectDetailDto, categoryMapping } from "./_type/project";
 
 interface Props {
   projectId: string;
@@ -127,7 +127,7 @@ export function ProjectDetailInfo({ projectId }: Props) {
   };
 
   const handleInquiryClick = () => {
-    router.push(`/infodesk/inquries/write?id=${projectId}`);
+    router.push(`/infodesk/inquiries/write?id=${projectId}`);
   };
 
   return (

--- a/src/components/pages/ProjectDetail/ProjectDetailInfo.tsx
+++ b/src/components/pages/ProjectDetail/ProjectDetailInfo.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useAuth } from "@/components/common/Auth";
 import { PrimaryButton } from "@/components/common/Buttons";
 import { CardBadge } from "@/components/common/CardBadge";
 import { CommonAxios } from "@/utils/CommonAxios";
@@ -90,15 +91,19 @@ export function ProjectDetailInfo({ projectId }: Props) {
     }
   };
 
+  const { isLoggedIn } = useAuth();
+
   const handleThumbupClick = async () => {
+    if (!isLoggedIn) {
+      alert("프로젝트에 좋아요를 표시하려면 로그인해야 합니다.");
+      return;
+    }
     if (isThumbup) {
-      // 좋아요 삭제
       const response = await CommonAxios.delete(`/projects/${projectId}/like`);
       if (response.status === 204) {
         handleRefresh();
       }
     } else {
-      // 좋아요 등록
       const response = await CommonAxios.post(`/projects/${projectId}/like`);
       if (response.status === 201) {
         handleRefresh();
@@ -107,26 +112,36 @@ export function ProjectDetailInfo({ projectId }: Props) {
   };
 
   const handleInterestClick = async () => {
+    if (!isLoggedIn) {
+      alert("프로젝트를 북마크에 추가하려면 로그인해야 합니다.");
+      return;
+    }
     if (isInterest) {
-      // 관심 삭제
       const response = await CommonAxios.delete(`/projects/${projectId}/favorite`);
-      if (response.status == 204) {
+      if (response.status === 204) {
         handleRefresh();
       }
     } else {
-      // 관심 등록
       const response = await CommonAxios.post(`/projects/${projectId}/favorite`);
-      if (response.status == 201) {
+      if (response.status === 201) {
         handleRefresh();
       }
     }
   };
 
   const handleProposalClick = () => {
+    if (!isLoggedIn) {
+      alert("산학 과제를 제안하려면 로그인해야 합니다.");
+      return;
+    }
     router.push("/infodesk/proposals");
   };
 
   const handleInquiryClick = () => {
+    if (!isLoggedIn) {
+      alert("프로젝트 문의를 하려면 로그인해야 합니다.");
+      return;
+    }
     router.push(`/infodesk/inquiries/write?id=${projectId}`);
   };
 

--- a/src/components/pages/ProjectDetail/ProjectDetailInquiry.tsx
+++ b/src/components/pages/ProjectDetail/ProjectDetailInquiry.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import { Text } from "@mantine/core";
-import classes from "./ProjectDetailInfo.module.css";
-import { useRouter } from "next/navigation";
 import { PrimaryButton } from "@/components/common/Buttons";
+import { Text } from "@mantine/core";
+import { useRouter } from "next/navigation";
+import classes from "./ProjectDetailInfo.module.css";
 
 interface Props {
   projectId: string;
@@ -13,7 +13,7 @@ export function ProjectDetailInquiry({ projectId }: Props) {
   const router = useRouter();
 
   const handleButtonClick = () => {
-    router.push(`/infodesk/inquries/write?id=${projectId}`);
+    router.push(`/infodesk/inquiries/write?id=${projectId}`);
   };
 
   return (


### PR DESCRIPTION
작성자: @github_nickname

## 체크 리스트

- [x] 적절한 제목으로 수정했나요?
- [x] 상단에 이슈 번호를 기입했나요?
- [x] Target Branch를 올바르게 설정했나요?
- [x] Label을 알맞게 설정했나요?

## 작업 내역

- 2군데 스펠링 미스가 남아있길래 마저 수정합니다.
- 프로젝트 상세조회 페이지에서 로그인 없이 프로젝트 문의, 좋아요, 북마크 클릭할 경우 경고를 띄우고 행위를 하지 못하도록 수정 (auth의 로그인 확인 기능을 이용)

## 비고

- 근데 프로젝트 문의 버튼이 프로젝트 상세조회에 위에 하나 아래하나 있어서 이게 두개나 있는 건가요?
