### PR TITLE
[FIX] 새 유저 회원 가입 창이 아닌 랜딩로 가는 문제/회원가입 완료 후 랜딩으로 못가는 문제 + 로그 아웃 미기능 문제 해결

### DIFF
--- a/src/components/common/Header/elements/HeaderToolBar.tsx
+++ b/src/components/common/Header/elements/HeaderToolBar.tsx
@@ -1,12 +1,12 @@
 "use client";
 
-import Image from "next/image";
-import styles from "../Header.module.css";
-import { IconLock, IconUser } from "@tabler/icons-react";
-import Link from "next/link";
 import { fetcher } from "@/utils/fetcher";
+import { IconLock, IconUser } from "@tabler/icons-react";
+import Image from "next/image";
+import Link from "next/link";
 import { useEffect, useState } from "react";
-import { CommonAxios } from "@/utils/CommonAxios";
+import { useAuth } from "../../Auth";
+import styles from "../Header.module.css";
 
 interface IHeaderToolBarProps {
   isOpen: boolean;
@@ -16,6 +16,8 @@ interface IHeaderToolBarProps {
 
 export function HeaderToolBar({ isOpen, setIsOpen, isLoggedIn }: IHeaderToolBarProps) {
   const [userData, setUserData] = useState<{ name: string } | null>(null);
+
+  const { logout } = useAuth();
 
   const toggleHamburger = () => {
     setIsOpen(!isOpen);
@@ -57,13 +59,7 @@ export function HeaderToolBar({ isOpen, setIsOpen, isLoggedIn }: IHeaderToolBarP
                     </Link>
                   </li>
                   <li>
-                    <a
-                      onClick={() => {
-                        CommonAxios.post("/auth/logout");
-                      }}
-                    >
-                      로그아웃
-                    </a>
+                    <a onClick={logout}>로그아웃</a>
                   </li>
                 </ul>
               </div>

--- a/src/components/common/RegisterForm/registerForm.tsx
+++ b/src/components/common/RegisterForm/registerForm.tsx
@@ -1,17 +1,18 @@
-import React, { useState } from "react";
-import { TextInput } from "@/components/common/TextInput/TextInput";
-import { Dropdown } from "@/components/common/Dropdown/Dropdown";
-import { CheckBox } from "@/components/common/CheckBox/CheckBox";
-import { PrimaryButton } from "@/components/common/Buttons/PrimaryButton/PrimaryButton";
-import classes from "./registerForm.module.css";
-// refresh token 안됨 !! 왜지 ??
-//import { getServerSideToken } from "@/components/common/Auth/getServerSideToken";
 import { useAuth } from "@/components/common/Auth/AuthProvider";
+import { PrimaryButton } from "@/components/common/Buttons/PrimaryButton/PrimaryButton";
+import { CheckBox } from "@/components/common/CheckBox/CheckBox";
+import { Dropdown } from "@/components/common/Dropdown/Dropdown";
+import { TextInput } from "@/components/common/TextInput/TextInput";
 import { CommonAxios } from "@/utils/CommonAxios/CommonAxios";
+import { useRouter } from "next/navigation"; // 추가
+import React, { useState } from "react";
+import classes from "./registerForm.module.css";
 
 const MEMBER_TYPES = ["학생", "교수/교직원", "기업관계자", "외부인"];
 const SIGNUP_SOURCES = ["학과 게시판", "s-top 홍보자료", "학과 카톡방", "지인 소개", "기타"];
+
 export function RegisterForm() {
+  const router = useRouter(); // 추가
   const [formData, setFormData] = useState({
     name: "",
     phoneNumber: "",
@@ -25,8 +26,6 @@ export function RegisterForm() {
 
   const [selectedMemberType, setSelectedMemberType] = useState<string | null>(null);
   const [selectedDepartment, setSelectedDepartment] = useState<string | null>(null);
-  //const [selectedSignupSource, setSelectedSignupSource] = useState<String | null>(null);
-
   const [acceptedTerms, setAcceptedTerms] = useState(false);
   const [acceptedPrivacy, setAcceptedPrivacy] = useState(false);
 
@@ -80,8 +79,6 @@ export function RegisterForm() {
     }
 
     try {
-      //const { accessToken, refreshToken } = await getServerSideToken()
-
       const config = {
         headers: { Authorization: `Bearer ${token}` },
         withCredentials: true,
@@ -94,6 +91,9 @@ export function RegisterForm() {
       );
 
       console.log("Registration Successful: ", response.data);
+
+      // 회원가입 성공 후 "/"로 이동
+      router.push("/");
     } catch (error) {
       console.error("Error registering: ", error);
     }

--- a/src/components/pages/KakaoAuth/KakaoAuth.tsx
+++ b/src/components/pages/KakaoAuth/KakaoAuth.tsx
@@ -1,12 +1,12 @@
 "use client";
 
 import { useAuth } from "@/components/common/Auth";
+import { JWT_COOKIE_NAME } from "@/constants/Auth";
+import { CustomJwtPayload } from "@/types/jwtPayload";
+import Cookies from "js-cookie";
+import { jwtDecode } from "jwt-decode";
 import { useRouter } from "next/navigation";
 import { useEffect } from "react";
-import Cookies from "js-cookie";
-import { JWT_COOKIE_NAME } from "@/constants/Auth";
-import { jwtDecode } from "jwt-decode";
-import { CustomJwtPayload } from "@/types/jwtPayload";
 
 export function KakaoAuth() {
   const router = useRouter();
@@ -18,7 +18,7 @@ export function KakaoAuth() {
     if (accessToken) {
       login(accessToken);
       const claims: CustomJwtPayload = jwtDecode(accessToken);
-      if (claims.type === "TEMP") {
+      if (claims.userType === "TEMP") {
         // 가입되지 않은 사용자
         router.push("/register");
       } else {

--- a/src/types/jwtPayload.ts
+++ b/src/types/jwtPayload.ts
@@ -2,5 +2,5 @@ import { JwtPayload } from "jwt-decode";
 import { Role } from "./user";
 
 export interface CustomJwtPayload extends JwtPayload {
-  type: Role;
+  userType: Role;
 }


### PR DESCRIPTION
작성자: @shj1081 

## 체크 리스트

- [x] 적절한 제목으로 수정했나요?
- [x] 상단에 이슈 번호를 기입했나요?
- [x] Target Branch를 올바르게 설정했나요?
- [x] Label을 알맞게 설정했나요?

## 작업 내역

- jwt 의 유저 타입을 담고있는 필드명인 `userType` 과 jwt 페이로드 필드명인  `type` 간의 이름 불일치로 나타난 문제임을 확인
- 페이로드 필드명 `userType` 으로 수정
- 회원 가입 완료 후 랜딩 페이지로 못돌아가는 문제는 router가 랜딩페이지로 push해주는 구문이 없어서 발생 -> 추가
- 로그아웃의 경우, onClick action이 AuthProvider의 logout 함수가 아닌 BE 로그아웃 api 로의 직접 요청만으로 설정되있어 나는 문제임을 확인
- 해당 onClick action 수정

## 비고

- 이건 진짜 찾는데, 오래 걸렸습니다...
- 로그가 브라우저에 찍히는 줄 몰라서 한참 해멨습니다.
- 이제 드디어 쿠키 한번 지우시면 시크릿 모드아니여도 로그인 로그아웃 멀쩡하게 가능합니다!!!
