### PR TITLE
[fix+edit] 노티스 상세보기 프로포절 추가, nav 주석처리

### DIFF
--- a/src/app/(user)/event/notices/[id]/page.tsx
+++ b/src/app/(user)/event/notices/[id]/page.tsx
@@ -49,7 +49,6 @@ export default function EventNoticeDetailPage() {
             <NoticeDetail
               heading={HEADING}
               item={data}
-              nav={{}}
               handleDownloadClick={handleDownloadClick}
             />
           )

--- a/src/app/(user)/infodesk/notices/[id]/page.tsx
+++ b/src/app/(user)/infodesk/notices/[id]/page.tsx
@@ -49,7 +49,6 @@ export default function NoticeDetailPage() {
             <NoticeDetail
               heading={HEADING}
               item={data}
-              nav={{}}
               handleDownloadClick={handleDownloadClick}
             />
           )

--- a/src/app/(user)/infodesk/proposals/[id]/page.tsx
+++ b/src/app/(user)/infodesk/proposals/[id]/page.tsx
@@ -22,10 +22,12 @@ export default function InquiriesDetailPage() {
   }, []);
 
   useEffect(() => {
+    if (!ID) return;
+
     const fetchData = async () => {
-      if (!ID) return;
+      setLoading(true); // 요청 시작 시 로딩 상태 변경
       try {
-        const response = await CommonAxios.get(`/inquiries/${ID}`);
+        const response = await CommonAxios.get(`/proposals/${ID}`);
         setData(response.data);
       } catch (err) {
         setError(err instanceof Error ? err : new Error("알 수 없는 오류가 발생했습니다."));
@@ -36,7 +38,7 @@ export default function InquiriesDetailPage() {
     if (!data && !error) {
       fetchData();
     }
-  }, [ID, data, error]);
+  }, [ID]);
 
   return (
     <>

--- a/src/components/common/NoticeDetail/NoticeDetail.module.css
+++ b/src/components/common/NoticeDetail/NoticeDetail.module.css
@@ -39,10 +39,15 @@
 }
 
 .container {
-  /* border-top: 1px solid var(--color-text); */
   border-top: 1px solid var(--mantine-color-text);
 }
-
+.content {
+  min-height: 80px; /* 최소 높이를 설정해서 글이 짧아도 여백이 생기도록 */
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between; /* 내용과 툴바를 아래쪽으로 밀기 */
+  margin-bottom: 20px;
+}
 .head {
   padding: 20px 15px;
   /* border-bottom: 1px solid var(--color-description); */
@@ -190,7 +195,10 @@
 }
 
 .toolbar {
-  margin: 20px 0;
+  margin: 40px 0 20px; /* 위쪽 마진을 늘려서 여백 추가 */
+  display: flex;
+  justify-content: flex-end; /* 버튼을 오른쪽 끝으로 정렬 */
+  position: relative;
 }
 
 .outlineTool {

--- a/src/components/common/NoticeDetail/NoticeDetail.story.tsx
+++ b/src/components/common/NoticeDetail/NoticeDetail.story.tsx
@@ -52,12 +52,6 @@ export const Usage: Story = {
         },
       ],
     },
-    nav: {
-      next_page: {
-        title: "이건 다음 글입니다.",
-        url: "/infodesk/notices/2",
-      },
-    },
     handleDownloadClick,
   },
 };

--- a/src/components/common/NoticeDetail/NoticeDetail.tsx
+++ b/src/components/common/NoticeDetail/NoticeDetail.tsx
@@ -1,20 +1,21 @@
 "use client";
 
-import { INoticeDetailItem, INoticeDetailNav } from "@/types/PageBoardTypes";
+//import { INoticeDetailItem, INoticeDetailNav } from "@/types/PageBoardTypes";
+import { INoticeDetailItem } from "@/types/PageBoardTypes";
 import { Button, Group } from "@mantine/core";
 import { IconMenu2, IconPinFilled } from "@tabler/icons-react";
 import styles from "./NoticeDetail.module.css";
-import { NoticeDetailSprint } from "./elements/NoticeDetailSprint";
+//import { NoticeDetailSprint } from "./elements/NoticeDetailSprint";
 import { NoticeDetailStage } from "./elements/NoticeDetailStage";
 
 type NoticeDetailProps = {
   heading: string;
   item: INoticeDetailItem;
-  nav: INoticeDetailNav;
+  //nav: INoticeDetailNav;
   handleDownloadClick: (id: number, name: string) => void;
 };
 
-export function NoticeDetail({ heading, item, nav, handleDownloadClick }: NoticeDetailProps) {
+export function NoticeDetail({ heading, item, handleDownloadClick }: NoticeDetailProps) {
   const CreatedDate = formatDate(new Date(item.createdAt ?? "NONE"));
   const EditedDate = formatDate(new Date(item.updatedAt ?? item.createdAt ?? "NONE"));
 
@@ -45,12 +46,14 @@ export function NoticeDetail({ heading, item, nav, handleDownloadClick }: Notice
             )}
           </Group>
         </div>
+        <div className={styles.content}>
         <NoticeDetailStage
           content={item.content}
           files={item.files}
           handleDownloadClick={handleDownloadClick}
         />
-        <NoticeDetailSprint prev_page={nav.prev_page} next_page={nav.next_page} />
+        {/*<NoticeDetailSprint prev_page={nav.prev_page} next_page={nav.next_page} />*/}
+        </div>
         <Group className={styles.toolbar} justify="start">
           <Button
             className={styles.outlineTool}


### PR DESCRIPTION
작성자: @moony1204 
이슈: #132 

## 체크 리스트

- [x] 적절한 제목으로 수정했나요?
- [x] 상단에 이슈 번호를 기입했나요?
- [x] Target Branch를 올바르게 설정했나요?
- [x] Label을 알맞게 설정했나요?

## 작업 내역

- proposals의 상세보기 페이지를 만들었습니다.
- 노티스 디테일의 레이아웃을 수정하였습니다.
- 노티스 디테일의 nav를 주석처리 하였습니다. (아무데도 안쓰길례 + 백엔드에서 안보내줌)

## 비고

- .
