### PR TITLE
대담 영상 퀴즈 모달에서 선지 선택 시 스크롤이 불가해지는 문제를 수정합니다. 

### DIFF
--- a/src/components/common/VideoCard/VideoCard.tsx
+++ b/src/components/common/VideoCard/VideoCard.tsx
@@ -108,85 +108,86 @@ export const VideoCard: React.FC<VideoCardProps> = ({
   };
 
   return (
-    <div
-      className={styles.container}
-      data-videoid={id}
-      ref={cardRef} // Attach the ref to the container
-      onClick={handleCardClick} // Add the click handler
-      style={{ cursor: "pointer" }} // Indicate clickable area
-    >
-      <div className={styles.videoFrame}>
-        <iframe
-          width="100%"
-          height="100%"
-          src={videoUrl}
-          frameBorder="0"
-          allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-          allowFullScreen
-          title="Embedded youtube"
-        />
-      </div>
-      <div className={styles.details}>
-        <div className={styles.title}>{title}</div>
-        <div className={styles.subtitle}>{subtitle}</div>
+    <>
+      <div
+        className={styles.container}
+        data-videoid={id}
+        ref={cardRef} // Attach the ref to the container
+        onClick={handleCardClick} // Add the click handler
+        style={{ cursor: "pointer" }} // Indicate clickable area
+      >
+        <div className={styles.videoFrame}>
+          <iframe
+            width="100%"
+            height="100%"
+            src={videoUrl}
+            frameBorder="0"
+            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+            allowFullScreen
+            title="Embedded youtube"
+          />
+        </div>
+        <div className={styles.details}>
+          <div className={styles.title}>{title}</div>
+          <div className={styles.subtitle}>{subtitle}</div>
 
-        <Group justify="space-between">
-          <div className={styles.bookmarkIcon} onClick={handleBookmarkClick}>
-            {bookmarked ? (
-              <svg
-                width="18"
-                height="20"
-                viewBox="0 0 18 20"
-                fill="none"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M1 7.2666C1 4.43817 1 3.02396 1.87868 2.14528C2.75736 1.2666 4.17157 1.2666 7 1.2666H11C13.8284 1.2666 15.2426 1.2666 16.1213 2.14528C17 3.02396 17 4.43817 17 7.2666V14.0942C17 16.7775 17 18.1191 16.1557 18.5295C15.3114 18.9399 14.2565 18.111 12.1465 16.4532L11.4713 15.9226C10.2849 14.9905 9.69173 14.5244 9 14.5244C8.30827 14.5244 7.71509 14.9905 6.52871 15.9226L5.85346 16.4532C3.74355 18.111 2.68859 18.9399 1.84429 18.5295C1 18.1191 1 16.7775 1 14.0942V7.2666Z"
-                  fill="#36618E"
-                  stroke="#36618E"
-                  strokeWidth="2"
-                />
-              </svg>
-            ) : (
-              <svg
-                width="18"
-                height="20"
-                viewBox="0 0 18 20"
-                fill="none"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M1 7C1 4.17157 1 2.75736 1.87868 1.87868C2.75736 1 4.17157 1 7 1H11C13.8284 1 15.2426 1 16.1213 1.87868C17 2.75736 17 4.17157 17 7V13.8276C17 16.5109 17 17.8525 16.1557 18.2629C15.3114 18.6733 14.2565 17.8444 12.1465 16.1866L11.4713 15.656C10.2849 14.7239 9.69173 14.2578 9 14.2578C8.30827 14.2578 7.71509 14.7239 6.52871 15.656L5.85346 16.1866C3.74355 17.8444 2.68859 18.6733 1.84429 18.2629C1 17.8525 1 16.5109 1 13.8276V7Z"
-                  stroke="#36618E"
-                  strokeWidth="2"
-                />
-              </svg>
-            )}
-          </div>
-          <Button size="xs" variant="light" radius="lg" color="#36618e" onClick={openQuizModal}>
-            퀴즈 풀기
-          </Button>
-        </Group>
-
-        <DetailsModal
-          opened={detailsModalOpened}
-          onClose={() => setDetailsModalOpened(false)}
-          videoUrl={videoUrl}
-          title={title}
-          subtitle={subtitle ?? ""}
-          onQuizButtonClick={handleQuizButtonClick}
-        />
-        {/* Quiz modal */}
-        <QuizModal
-          opened={quizModalOpened}
-          onClose={closeQuizModal}
-          videoUrl={videoUrl}
-          quizData={quizData} // Pass the quiz data here
-          title={title} // title prop 전달
-          subtitle={subtitle ?? ""}
-          onSubmit={submitQuiz}
-        />
+          <Group justify="space-between">
+            <div className={styles.bookmarkIcon} onClick={handleBookmarkClick}>
+              {bookmarked ? (
+                <svg
+                  width="18"
+                  height="20"
+                  viewBox="0 0 18 20"
+                  fill="none"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M1 7.2666C1 4.43817 1 3.02396 1.87868 2.14528C2.75736 1.2666 4.17157 1.2666 7 1.2666H11C13.8284 1.2666 15.2426 1.2666 16.1213 2.14528C17 3.02396 17 4.43817 17 7.2666V14.0942C17 16.7775 17 18.1191 16.1557 18.5295C15.3114 18.9399 14.2565 18.111 12.1465 16.4532L11.4713 15.9226C10.2849 14.9905 9.69173 14.5244 9 14.5244C8.30827 14.5244 7.71509 14.9905 6.52871 15.9226L5.85346 16.4532C3.74355 18.111 2.68859 18.9399 1.84429 18.5295C1 18.1191 1 16.7775 1 14.0942V7.2666Z"
+                    fill="#36618E"
+                    stroke="#36618E"
+                    strokeWidth="2"
+                  />
+                </svg>
+              ) : (
+                <svg
+                  width="18"
+                  height="20"
+                  viewBox="0 0 18 20"
+                  fill="none"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M1 7C1 4.17157 1 2.75736 1.87868 1.87868C2.75736 1 4.17157 1 7 1H11C13.8284 1 15.2426 1 16.1213 1.87868C17 2.75736 17 4.17157 17 7V13.8276C17 16.5109 17 17.8525 16.1557 18.2629C15.3114 18.6733 14.2565 17.8444 12.1465 16.1866L11.4713 15.656C10.2849 14.7239 9.69173 14.2578 9 14.2578C8.30827 14.2578 7.71509 14.7239 6.52871 15.656L5.85346 16.1866C3.74355 17.8444 2.68859 18.6733 1.84429 18.2629C1 17.8525 1 16.5109 1 13.8276V7Z"
+                    stroke="#36618E"
+                    strokeWidth="2"
+                  />
+                </svg>
+              )}
+            </div>
+            <Button size="xs" variant="light" radius="lg" color="#36618e" onClick={openQuizModal}>
+              퀴즈 풀기
+            </Button>
+          </Group>
+        </div>
       </div>
-    </div>
+      <DetailsModal
+        opened={detailsModalOpened}
+        onClose={() => setDetailsModalOpened(false)}
+        videoUrl={videoUrl}
+        title={title}
+        subtitle={subtitle ?? ""}
+        onQuizButtonClick={handleQuizButtonClick}
+      />
+      {/* Quiz modal */}
+      <QuizModal
+        opened={quizModalOpened}
+        onClose={closeQuizModal}
+        videoUrl={videoUrl}
+        quizData={quizData} // Pass the quiz data here
+        title={title} // title prop 전달
+        subtitle={subtitle ?? ""}
+        onSubmit={submitQuiz}
+      />
+    </>
   );
 };


### PR DESCRIPTION
작성자: @jaychang99

## 체크 리스트

- [x] 적절한 제목으로 수정했나요?
- [ ] 상단에 이슈 번호를 기입했나요?
- [x] Target Branch를 올바르게 설정했나요?
- [x] Label을 알맞게 설정했나요?

## 작업 내역

아래와 같은 이슈가 있어서 수정합니다. 

* 모바일 환경에서 퀴즈 모달 실행한 상태에서 퀴즈 선지를 누르는 순간, 화면 스크롤이 막혀서 다음 문제로 못 넘어감 '

아래 이미지 참고 부탁드립니다. 

![image](https://github.com/user-attachments/assets/5e9073ee-e3bd-4212-94a0-58dc2f8df62d)


* 문제의 원인 
지금 카드 UI 에 onClick 으로 `handleCardClick()` 이 이벤트 핸들러로 걸려있는데요,
문제는 카드 UI 를 감싸는 최외곽 div 안에 `<DetailsModal />` 과 `<QuizModal />` 이 들어있습니다.
그래서 모달 안에서의 어떤 클릭도, 카드를 클릭하는 동작처럼 작동할 것입니다.

(이벤트 버블링 — React 는 자체적인 이벤트 핸들링 메커니즘이 있습니다. 이벤트 버블링은 Modal 과 같은 portal 을 이용하는 경우라도 React 내부 메커니즘으로 JSX 상의 상위 요소로 버블링됩니다.)

일단 임시방편으로 `<VideoCard />` 최외곽을 `<></>` (React.Fragment) 로 감싸고, 카드 UI, 그리고 2개의 모달이 같은 수준에서 sibling 관계로 있을 수 있도록 했어요.

더 이상 div 의 onClick 핸들러가, 모달 내부 클릭에 반응하지 않습니다.

`<DetailsModal />` 내부에서 발생한 클릭 또한 handleCardClick() 을 호출했을 것입니다.

그러나 이미 detailsModalOpened 상태가 true 여서 눈에 띄는 UI 변화는 발생하지 않았을 것 같습니다.

(아! 참고로 추가적으로 말씀드리자면 내부에서도 react state 의 베일아웃(bailout) 이라는 것을 통해서 리-렌더링은 발생하지 않았을 것입니다. Bailout 은 상태를 변경하는 setter 함수가 호출되어도 (여기서는 setDetailsModalOpened 함수) , 이전 상태와 같은 값으로 변경을 시도하는 경우, 굳이 불필요하게 리렌더링 시키지 않는 것입니다. )

지금은 원시 값 (boolean) 이어서 단순히 ‘같다’ 를 쉽게 논할 수 있는데 내부적으로는 `Object.is()` 를 통해 두 값이 같은지 얕은 비교 (참조 비교) 를 해서 베일아웃 여부를 판단합니다.


## 비고

- 참고 사항을 적어주세요. 코드 리뷰하는 사람이 참고해야 하는 내용을 자유로운 형식으로 적을 수 있습니다.

close/resolve/fix #{이슈 번호 기입}
