### PR TITLE
fix: 회원가입 시 유저타입이 벡엔드의 유저타입 이름과 일치하지 않는 무제

### DIFF
--- a/src/components/common/RegisterForm/registerForm.tsx
+++ b/src/components/common/RegisterForm/registerForm.tsx
@@ -54,9 +54,9 @@ export function RegisterForm() {
         type === "학생"
           ? "STUDENT"
           : type === "교수/교직원"
-            ? "FACULTY"
+            ? "INACTIVE_PROFESSOR"
             : type === "기업관계자"
-              ? "COMPANY_REP"
+              ? "INACTUVE_COMPANY"
               : "EXTERNAL",
     }));
     setSelectedDepartment(null);

--- a/src/components/common/RegisterForm/registerForm.tsx
+++ b/src/components/common/RegisterForm/registerForm.tsx
@@ -56,7 +56,7 @@ export function RegisterForm() {
           : type === "교수/교직원"
             ? "INACTIVE_PROFESSOR"
             : type === "기업관계자"
-              ? "INACTUVE_COMPANY"
+              ? "INACTIVE_COMPANY"
               : "EXTERNAL",
     }));
     setSelectedDepartment(null);


### PR DESCRIPTION
작성자: @shj1081

## 체크 리스트

- [ ] 적절한 제목으로 수정했나요?
- [ ] 상단에 이슈 번호를 기입했나요?
- [ ] Target Branch를 올바르게 설정했나요?
- [ ] Label을 알맞게 설정했나요?

## 작업 내역



## 비고

