### PR TITLE
카카오 로그인 하고 처음으로 돌아온 직후 Loading 표시 지속되고 이름 표시 안 되는 문제 임시로 해결

### DIFF
--- a/src/utils/fetcher/fetcher.ts
+++ b/src/utils/fetcher/fetcher.ts
@@ -1,6 +1,7 @@
 import { getServerSideToken } from "@/components/common/Auth";
-import { REFRESH_TOKEN_NAME } from "@/constants/Auth";
+import { JWT_COOKIE_NAME, REFRESH_TOKEN_NAME } from "@/constants/Auth";
 import { CommonAxios } from "@/utils/CommonAxios";
+import Cookies from "js-cookie";
 
 export interface FetcherArgs {
   url: string;
@@ -16,8 +17,7 @@ export interface FetcherArgs {
  * @returns api 서버로부터 반환되는 데이터
  */
 export async function fetcher({ url, query }: FetcherArgs) {
-  const { accessToken } = await getServerSideToken();
-
+  const { accessToken } = await getIsomorphicToken();
   CommonAxios.defaults.headers.Authorization = `Bearer ${accessToken}`;
   CommonAxios.defaults.withCredentials = true;
 
@@ -43,3 +43,17 @@ export async function ServerSideFetcher({ url, query }: FetcherArgs) {
 
   return (await CommonAxios.get(url, config)).data;
 }
+
+const getIsomorphicToken = async () => {
+  if (typeof window !== "undefined") {
+    // 브라우저 환경
+    const accessToken = Cookies.get(JWT_COOKIE_NAME);
+    return { accessToken };
+  } else {
+    // 서버 환경
+    // getServerSideToken 내부의 next/headers 에서 가져오는 cookies 가
+    // 클라이언트 프로덕션 환경에서는 문제를 일으켜서 우선 임시로 이렇게 해결
+    const { accessToken } = await getServerSideToken();
+    return { accessToken };
+  }
+};


### PR DESCRIPTION
작성자: @jaychang99

## 체크 리스트

- [x] 적절한 제목으로 수정했나요?
- [ ] 상단에 이슈 번호를 기입했나요?
- [x] Target Branch를 올바르게 설정했나요?
- [x] Label을 알맞게 설정했나요?

## 작업 내역

* `getServerSideToken()` 내부에서 `next/headers` 의 cookies 함수를 씁니다. 
* 그런데 이것이 server-side 에서만 이용가능해서, 프로덕션 모드로 코드를 작동시키면, 문제를 일으킵니다. (서버에서 실행되어야 할 코드가 클라이언트에서 실행되는 경우가 있습니다)
* 근본적인 해결책은 아니지만, 우선 `getIsomorphicToken` 이라는 새로운 함수를 만들어, 서버와 클라이언트에서 일단 다르게 동작할 수 있도록 했습니다. 최소한의 수정을 가하려는 의도가 있었습니다. 

## 비고

- 참고 사항을 적어주세요. 코드 리뷰하는 사람이 참고해야 하는 내용을 자유로운 형식으로 적을 수 있습니다.

close/resolve/fix #{이슈 번호 기입}
