### PR TITLE
AuthProvider 의 로그인 함수 호출로 인한 무한 리렌더링 이슈 해결

### DIFF
--- a/src/components/common/Auth/AuthProvider.tsx
+++ b/src/components/common/Auth/AuthProvider.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { createContext, useContext, useEffect, useState } from "react";
+import { createContext, useCallback, useContext, useEffect, useState } from "react";
 import { JWT_COOKIE_NAME, JWT_MAX_AGE } from "@/constants/Auth";
 import { CommonAxios } from "@/utils/CommonAxios";
 import Cookies from "js-cookie";
@@ -55,7 +55,9 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     }
   }, [token]);
 
-  function login(token: string) {
+  // useCallback 으로 감싸주지 않으면, `useAuth()` 사용처에서 의존성 배열에 이 함수를 넣을 경우
+  // 무한 렌더링이 발생할 수 있습니다.
+  const login = useCallback((token: string) => {
     setIsLoadingCookie(true);
 
     setToken(token);
@@ -67,7 +69,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       fetchMe(); // 토큰 설정 후 약간의 딜레이를 두고 me API 호출
       setIsLoadingCookie(false);
     }, 0);
-  }
+  }, []);
 
   function logout() {
     setIsLoadingCookie(true);


### PR DESCRIPTION
작성자: @jaychang99

## 체크 리스트

- [x] 적절한 제목으로 수정했나요?
- [ ] 상단에 이슈 번호를 기입했나요?
- [x] Target Branch를 올바르게 설정했나요?
- [x] Label을 알맞게 설정했나요?

## 작업 내역

`<AuthProvider />` 의 무한 리렌더링으로 인해 초기접속 시 `/users/me` API 가 어떤 때는 1,000 회 이상 호출되는 경우가 있었습니다. 

`<AuthProvider />` 의 무한 리렌더링 원인 공유 

https://systemconsult-vqd4955.slack.com/archives/C079TP0861Y/p1739079535624679?thread_ts=1739076747.208969&cid=C079TP0861Y

```
아 <KakaoAuth /> 에 login 이 useEffect() 의 의존성 배열에 들어가있네요!
이렇게 되면 login 함수가 새로 생성될 때마다, 이 내부 로직이 돌아서, 무한 루프에 빠질 위험성이 있어요
지금같은 경우, login 함수 안에서 <AuthProvider /> 내부의 state 를 변경하고 있기 때문에
<KakaoAuth /> 에서 login 함수 호출
=> <AuthProvider /> 내부 상태 변경
=> <AuthProvider /> 내부 상태가 변경되었으니 리렌더링
=> login 함수 새로 생성됨 (참조 변경됨)
=> <KakaoAuth /> 의 useEffect 의 의존성 배열에 login 함수 있고, Object.is() 로 이전 함수랑 비교했을 때 달라졌음
=> <KakaoAuth /> 의 useEffect 내의 코드 재실행
=> <KakaoAuth /> 에서 login 함수 호출
=> (무한 반복….)
이렇게 된 것으로 보입니다.
```

```
이렇게 <AuthProvider /> 내부 login 을 선언하는 곳에서 useCallback() 을 이용해, 최초 렌더링 때에 생성한 login 함수를 계속 쓸 수 있도록 임시로 조치를 해봤어요.
만약 login 함수가 내부에서 상태나 prop 등 실제로 변경이 될 가능성이 있는 값을 참조하는 경우, 이것들을 모두 useCallback() 의 의존성 배열 내에 넣어줘야 했겠지만,
지금은 그런 값들은 보이지 않아서, 빈 의존성 배열로 넣어 주었어요!
아, 그리고 setIsLoadingCookie, setToken 과 같은 useState() 가 배열의 두 번째 항목으로 반환하는 setter function 은 자체적으로 stable 한 identity 를 갖고 있습니다. 그 말인즉슨, 이들은 리렌더링이 일어나도, 항상 같은 참조를 가지는 그 함수를 갖고 있다는 말이에요.

```

 (참고 - https://react.dev/learn/synchronizing-with-effects#:~:text=The%20set%20functions%20returned%20by%20useState%20also%20have%20stable%20identity%2C%20so%20you%20will%20often%20see%20them%20omitted%20from%20the%20dependencies%20too.%20If%20the%20linter%20lets%20you%20omit%20a%20dependency%20without%20errors%2C%20it%20is%20safe%20to%20do.)

## 비고

- 참고 사항을 적어주세요. 코드 리뷰하는 사람이 참고해야 하는 내용을 자유로운 형식으로 적을 수 있습니다.

close/resolve/fix #{이슈 번호 기입}
