### PR TITLE
fix: accessToken 이 없는 경우 undefined 대신 null 을 보내어 에러를 해결한다

### DIFF
--- a/src/utils/fetcher/fetcher.ts
+++ b/src/utils/fetcher/fetcher.ts
@@ -48,12 +48,12 @@ const getIsomorphicToken = async () => {
   if (typeof window !== "undefined") {
     // 브라우저 환경
     const accessToken = Cookies.get(JWT_COOKIE_NAME);
-    return { accessToken };
+    return { accessToken: accessToken ?? null };
   } else {
     // 서버 환경
     // getServerSideToken 내부의 next/headers 에서 가져오는 cookies 가
     // 클라이언트 프로덕션 환경에서는 문제를 일으켜서 우선 임시로 이렇게 해결
     const { accessToken } = await getServerSideToken();
-    return { accessToken };
+    return { accessToken: accessToken ?? null };
   }
 };


### PR DESCRIPTION
작성자: @github_nickname

## 체크 리스트

- [x] 적절한 제목으로 수정했나요?
- [ ] 상단에 이슈 번호를 기입했나요?
- [x] Target Branch를 올바르게 설정했나요?
- [x] Label을 알맞게 설정했나요?

## 작업 내역

이슈 슬랙: https://systemconsult-vqd4955.slack.com/archives/C079TP0861Y/p1739105802170599

- 로그인 안 한 상태에서 프로젝트 보이지 않는 문제 해결
- accessToken 이 없는 경우 undefined 가 아니라 null 로 보내야 백엔드 서버에서 적절히 핸들링함. 
- https://github.com/SystemConsultantGroup/S-top-backend/blob/develop/src/main/java/com/scg/stop/auth/config/AuthUserArgumentResolver.java#L104


## 비고

- 참고 사항을 적어주세요. 코드 리뷰하는 사람이 참고해야 하는 내용을 자유로운 형식으로 적을 수 있습니다.

close/resolve/fix #{이슈 번호 기입}
