### PR TITLE
[FIX] 프로젝트 페이지 탭이동시 좋아요, 북마크 등 고정되어있는 버그 수정

### DIFF
--- a/src/components/common/ProjectCard/ProjectCardLikeSection.tsx
+++ b/src/components/common/ProjectCard/ProjectCardLikeSection.tsx
@@ -8,7 +8,7 @@ import {
   IconThumbUpFilled,
 } from "@tabler/icons-react";
 import classes from "./ProjectCard.module.css";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useAuth } from "../Auth";
 
 export interface ProjectCardLikeSectionProps {
@@ -49,6 +49,13 @@ export function ProjectCardLikeSection({
       alert("프로젝트를 북마크에 추가하려면 로그인해야 합니다.");
     }
   };
+
+  useEffect(() => {
+    setLike(likes);
+    setIsLike(isLiked);
+    setIsMark(isMarked);
+  }, [likes, isLiked, isMarked]);
+  
   return (
     <CardSection className={classes["like-section"]}>
       <Group align="center" justify="space-between" p="8px 16px">


### PR DESCRIPTION
작성자: @hynseok 

## 체크 리스트

- [x] 적절한 제목으로 수정했나요?
- [ ] 상단에 이슈 번호를 기입했나요?
- [x] Target Branch를 올바르게 설정했나요?
- [x] Label을 알맞게 설정했나요?

## 작업 내역

- 프로젝트 페이지 2025 탭과 전체 탭을 왔다갔다할 시 값이 고정되어있는 버그 및   
좋아요 클릭 후 탭 이동시 반영 안되는 버그 등 수정

## 비고

