### PR TITLE
feat/238-cardLayout/page-layout video pages+dropdown modified

### DIFF
--- a/src/app/(user)/interviews/interviews.module.css
+++ b/src/app/(user)/interviews/interviews.module.css
@@ -8,10 +8,10 @@
 
 /* Main content section */
 .mainContent {
-  width: 90%;
+  width: 100%;
   max-width: 1440px;
   margin: 0 auto;
-  /* padding: 0 20px; */
+  padding: 0 1.5rem 6rem;
   box-sizing: border-box;
   padding-bottom: 100px;
   display: flex;
@@ -21,77 +21,30 @@
 }
 
 .searchSection {
-  margin-top: 40px;
-  margin-bottom: 20px;
-  justify-content: center;
-
-  width: 1280px;
-
-  @media screen and (max-width: 1280px) {
-    /** 태블릿 가로, 노트북 */
-    width: 1024px;
-  }
-
-  @media screen and (max-width: 1024px) {
-    /** 태블릿 가로 */
-    width: 768px;
-  }
-
-  @media screen and (max-width: 768px) {
-    /** 모바일 가로, 태블릿 세로 */
-    width: 100%;
-    padding: 0 20px;
-  }
-
-  @media screen and (max-width: 480px) {
-    /** 모바일 세로 */
-    width: 100%;
-    padding: 0 10px;
-  }
+  width: 80%;
+  margin: 2.5rem auto 1rem;
 }
 
 .filters {
   display: flex;
   justify-content: flex-end;
-  margin-top: 20px;
-  margin-right: 20px;
+  padding-right: 1rem;   
+  margin-top: 1rem;
 }
 
 .dropdown {
   margin-right: 0px;
 }
 
-/* Grid container for video cards */
 .videoGrid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(350px, 1fr));
-  /* Adjusts the number of columns based on screen size */
-  gap: 20px;
-  margin-top: 40px;
-
-  width: 1280px;
-
-  @media screen and (max-width: 1280px) {
-    /** 태블릿 가로, 노트북 */
-    width: 1024px;
-  }
-
-  @media screen and (max-width: 1024px) {
-    /** 태블릿 가로 */
-    width: 768px;
-  }
-
-  @media screen and (max-width: 768px) {
-    /** 모바일 가로, 태블릿 세로 */
-    width: 100%;
-    padding: 0 20px;
-  }
-
-  @media screen and (max-width: 480px) {
-    /** 모바일 세로 */
-    width: 100%;
-    padding: 0 10px;
-  }
+  gap: 1.25rem;                  
+  grid-template-columns: repeat(
+    auto-fit,
+    minmax(260px, 1fr)              
+  );
+  width: 100%;                      
+  margin-top: 2.5rem;
 }
 
 @media screen and (max-width: 480px) {
@@ -100,13 +53,8 @@
     font-size: 28px; /* 더 작은 폰트 크기 */
   }
 
-  .search {
-    padding: 30px 15px 0; /* 상단과 양측 패딩 조정 */
-  }
-
-  .dropdown {
-    margin-top: 15px;
-    margin-bottom: 30px;
+  .searchSection {
+    width: 100%;
   }
 
   .videoGrid {
@@ -121,23 +69,22 @@
     font-size: 30px; /* 적절한 크기 */
   }
 
-  .search {
-    padding: 40px 20px 0;
+  .searchSection {
+    width: 90%;
   }
 
-  .dropdown {
-    margin-top: 20px;
-    margin-bottom: 40px;
-  }
-
-  .videoGrid {
-    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr)); /* 작은 카드 크기 */
-  }
 }
 
 @media screen and (max-width: 1024px) {
   /** 태블릿 가로 */
   .videoGrid {
-    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr)); /* 더 큰 카드 크기 */
+    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr)); 
+  }
+}
+
+@media (min-width: 1440px) {
+  .videoGrid {
+    grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+    gap: 1.5rem;
   }
 }

--- a/src/app/(user)/interviews/page.tsx
+++ b/src/app/(user)/interviews/page.tsx
@@ -131,9 +131,9 @@ export default function InterviewsPage() {
                 selectedOption={yearFilter}
                 onOptionClick={handleYearSelect}
               />
-            </div>
+            </div> 
           </div>
-        </div>
+        </div> 
         <div className={classes.videoGrid}>
           {videoData.map((video) =>
             video.id ? ( // Check if video.id exists

--- a/src/app/(user)/jobfair/advices/jobfair.module.css
+++ b/src/app/(user)/jobfair/advices/jobfair.module.css
@@ -1,98 +1,63 @@
-.search {
-  margin: 0 auto; /* 중앙 정렬 */
-  padding: 50px 0 0; /* 모바일 환경에 맞게 상단과 양측 패딩 조정 */
-  width: 1280px;
-
-  @media screen and (max-width: 1280px) {
-    /** 태블릿 가로, 노트북 */
-    width: 1024px;
-  }
-
-  @media screen and (max-width: 1024px) {
-    /** 태블릿 가로 */
-    width: 768px;
-  }
-
-  @media screen and (max-width: 768px) {
-    /** 모바일 가로, 태블릿 세로 */
-    width: 100%;
-    padding: 0 20px;
-  }
-
-  @media screen and (max-width: 480px) {
-    /** 모바일 세로 */
-    width: 100%;
-    padding: 0 10px;
-  }
-}
-
 .title {
   font-size: 32px;
   font-weight: bold;
-  margin-bottom: 40px;
+  align-self: flex-start;
+  margin-left: 4rem;
 }
 
-.backColor {
-  background-color: var(--color-surfaceContainerLowest);
+/* Banner section */
+.banner {
+  width: 100%;
+  padding: 0;
+  box-sizing: border-box;
+  margin-bottom: 20px;
+}
+
+/* Main content section */
+.mainContent {
+  width: 100%;
+  max-width: 1440px;
+  margin: 0 auto;
+  padding: 0 1.5rem 6rem;
+  box-sizing: border-box;
+  padding-bottom: 100px;
   display: flex;
-  justify-content: center; /* 콘텐츠를 가로로 중앙에 정렬 */
-  align-items: center; /* 콘텐츠를 세로로 중앙에 정렬 */
-  flex-direction: column; /* 자식 요소들을 수직으로 정렬 */
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+}
+
+.searchSection {
+  width: 80%;
+  margin: 2.5rem auto 1rem;
+}
+
+.filters {
+  display: flex;
+  justify-content: flex-end;
+  padding-right: 1rem;   
+  margin-top: 1rem;
 }
 
 .dropdown {
-  margin-top: 20px;
-  text-align: right; /* Dropdown을 오른쪽 정렬 */
-  margin-bottom: 60px;
+  margin-right: 0px;
 }
 
 .videoGrid {
-  width: 100%;
-  /* max-width: 1300px; */
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(350px, 1fr));
-  gap: 20px;
-  margin-bottom: 80px;
-  /* padding: 0 25px; */
-
-  width: 1280px;
-
-  @media screen and (max-width: 1280px) {
-    /** 태블릿 가로, 노트북 */
-    width: 1024px;
-  }
-
-  @media screen and (max-width: 1024px) {
-    /** 태블릿 가로 */
-    width: 768px;
-  }
-
-  @media screen and (max-width: 768px) {
-    /** 모바일 가로, 태블릿 세로 */
-    width: 100%;
-    padding: 0 20px;
-  }
-
-  @media screen and (max-width: 480px) {
-    /** 모바일 세로 */
-    width: 100%;
-    padding: 0 10px;
-  }
+  gap: 1.25rem;                  
+  grid-template-columns: repeat(
+    auto-fit,
+    minmax(260px, 1fr)              
+  );
+  width: 100%;                      
+  margin-top: 2.5rem;
 }
 
 @media screen and (max-width: 480px) {
   /** 모바일 세로 */
-  .title {
-    font-size: 28px; /* 더 작은 폰트 크기 */
-  }
-
-  .search {
-    padding: 30px 15px 0; /* 상단과 양측 패딩 조정 */
-  }
-
-  .dropdown {
-    margin-top: 15px;
-    margin-bottom: 30px;
+  .searchSection {
+    width: 100%;
   }
 
   .videoGrid {
@@ -103,27 +68,22 @@
 
 @media screen and (max-width: 768px) {
   /** 모바일 가로, 태블릿 세로 */
-  .title {
-    font-size: 30px; /* 적절한 크기 */
+  .searchSection {
+    width: 90%;
   }
 
-  .search {
-    padding: 40px 20px 0;
-  }
-
-  .dropdown {
-    margin-top: 20px;
-    margin-bottom: 40px;
-  }
-
-  .videoGrid {
-    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr)); /* 작은 카드 크기 */
-  }
 }
 
 @media screen and (max-width: 1024px) {
   /** 태블릿 가로 */
   .videoGrid {
-    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr)); /* 더 큰 카드 크기 */
+    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr)); 
+  }
+}
+
+@media (min-width: 1440px) {
+  .videoGrid {
+    grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+    gap: 1.5rem;
   }
 }

--- a/src/app/(user)/jobfair/advices/page.tsx
+++ b/src/app/(user)/jobfair/advices/page.tsx
@@ -95,8 +95,8 @@ const JobFairPage = () => {
   };
 
   return (
-    <div>
-      <div className={styles.container}>
+    <>
+      <div className={styles.banner}>
         <SubHeadNavbar title="Job Fair" />
         <Banner
           type="PROJECT"
@@ -105,19 +105,22 @@ const JobFairPage = () => {
           text="S-TOP Job Fair는 현업에 종사하고 있는 선배 개발자님들과 실무 경험을 얻고자 하는 학생들을 연결하여, IT 인재 양성 문화를 함께 만들기 위해 기획되었습니다."
         />
       </div>
-      <div className={styles.backColor}>
-        <div className={styles.search}>
-          <h2 className={styles.title}>선배님들의 조언</h2>
-          <div className={styles.searchArea}>
-            <SearchInput placeholder="영상 검색" onChange={(e) => setSearchQuery(e.target.value)} />
-          </div>
-          <div className={styles.dropdown}>
-            <Dropdown
-              options={YEARS}
-              placeholder="전체"
-              selectedOption={selectedYear}
-              onOptionClick={handleYearSelect}
-            />
+      <div className={styles.mainContent}>
+        <h2 className={styles.title}>선배님들의 조언</h2>
+        <div className={styles.searchSection}>
+          <SearchInput
+            placeholder={"현직자 인터뷰 영상 검색"} 
+            onChange={(e) => setSearchQuery(e.target.value)} 
+          />
+          <div className={styles.filters}>
+            <div className={styles.dropdown}>
+              <Dropdown
+                options={YEARS}
+                placeholder="전체"
+                selectedOption={selectedYear}
+                onOptionClick={handleYearSelect}
+              />
+            </div>
           </div>
         </div>
         <div className={styles.videoGrid}>
@@ -135,7 +138,7 @@ const JobFairPage = () => {
           ))}
         </div>
       </div>
-    </div>
+    </>
   );
 };
 

--- a/src/app/(user)/jobfair/interns/jonfairInterns.module.css
+++ b/src/app/(user)/jobfair/interns/jonfairInterns.module.css
@@ -1,110 +1,63 @@
-.search {
-  margin: 0 auto; /* 중앙 정렬 */
-  padding: 50px 0 0; /* 모바일 환경에 맞게 상단과 양측 패딩 조정 */
-  width: 1280px;
-
-  @media screen and (max-width: 1280px) {
-    /** 태블릿 가로, 노트북 */
-    width: 1024px;
-  }
-
-  @media screen and (max-width: 1024px) {
-    /** 태블릿 가로 */
-    width: 768px;
-  }
-
-  @media screen and (max-width: 768px) {
-    /** 모바일 가로, 태블릿 세로 */
-    width: 100%;
-    padding: 0 20px;
-  }
-
-  @media screen and (max-width: 480px) {
-    /** 모바일 세로 */
-    width: 100%;
-    padding: 0 10px;
-  }
-}
-
 .title {
   font-size: 32px;
   font-weight: bold;
-  margin-bottom: 40px;
+  align-self: flex-start;
+  margin-left: 4rem;
 }
 
-.backColor {
-  background-color: var(--color-surfaceContainerLowest);
+/* Banner section */
+.banner {
+  width: 100%;
+  padding: 0;
+  box-sizing: border-box;
+  margin-bottom: 20px;
+}
+
+/* Main content section */
+.mainContent {
+  width: 100%;
+  max-width: 1440px;
+  margin: 0 auto;
+  padding: 0 1.5rem 6rem;
+  box-sizing: border-box;
+  padding-bottom: 100px;
   display: flex;
-  justify-content: center; /* 콘텐츠를 가로로 중앙에 정렬 */
-  align-items: center; /* 콘텐츠를 세로로 중앙에 정렬 */
-  flex-direction: column; /* 자식 요소들을 수직으로 정렬 */
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+}
+
+.searchSection {
+  width: 80%;
+  margin: 2.5rem auto 1rem;
+}
+
+.filters {
+  display: flex;
+  justify-content: flex-end;
+  padding-right: 1rem;   
+  margin-top: 1rem;
 }
 
 .dropdown {
-  margin-top: 20px;
-  text-align: right; /* Dropdown을 오른쪽 정렬 */
-  margin-bottom: 60px;
+  margin-right: 0px;
 }
 
 .videoGrid {
-  width: 100%;
-  /* max-width: 1300px; */
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(350px, 1fr));
-  gap: 20px;
-  margin-bottom: 80px;
-  /* padding: 0 25px; */
-
-  width: 1280px;
-
-  @media screen and (max-width: 1280px) {
-    /** 태블릿 가로, 노트북 */
-    width: 1024px;
-  }
-
-  @media screen and (max-width: 1024px) {
-    /** 태블릿 가로 */
-    width: 768px;
-  }
-
-  @media screen and (max-width: 768px) {
-    /** 모바일 가로, 태블릿 세로 */
-    width: 100%;
-    padding: 0 20px;
-  }
-
-  @media screen and (max-width: 480px) {
-    /** 모바일 세로 */
-    width: 100%;
-    padding: 0 10px;
-  }
+  gap: 1.25rem;                  
+  grid-template-columns: repeat(
+    auto-fit,
+    minmax(260px, 1fr)              
+  );
+  width: 100%;                      
+  margin-top: 2.5rem;
 }
 
 @media screen and (max-width: 480px) {
   /** 모바일 세로 */
-}
-
-@media screen and (max-width: 768px) {
-  /** 모바일 가로, 태블릿 세로 */
-}
-
-@media screen and (max-width: 1280px) {
-  /** 태블릿 가로, 노트북 */
-}
-
-@media screen and (max-width: 480px) {
-  /** 모바일 세로 */
-  .title {
-    font-size: 28px; /* 더 작은 폰트 크기 */
-  }
-
-  .search {
-    padding: 30px 15px 0; /* 상단과 양측 패딩 조정 */
-  }
-
-  .dropdown {
-    margin-top: 15px;
-    margin-bottom: 30px;
+  .searchSection {
+    width: 100%;
   }
 
   .videoGrid {
@@ -115,27 +68,22 @@
 
 @media screen and (max-width: 768px) {
   /** 모바일 가로, 태블릿 세로 */
-  .title {
-    font-size: 30px; /* 적절한 크기 */
+  .searchSection {
+    width: 90%;
   }
 
-  .search {
-    padding: 40px 20px 0;
-  }
-
-  .dropdown {
-    margin-top: 20px;
-    margin-bottom: 40px;
-  }
-
-  .videoGrid {
-    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr)); /* 작은 카드 크기 */
-  }
 }
 
 @media screen and (max-width: 1024px) {
   /** 태블릿 가로 */
   .videoGrid {
-    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr)); /* 더 큰 카드 크기 */
+    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr)); 
+  }
+}
+
+@media (min-width: 1440px) {
+  .videoGrid {
+    grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+    gap: 1.5rem;
   }
 }

--- a/src/app/(user)/jobfair/interns/page.tsx
+++ b/src/app/(user)/jobfair/interns/page.tsx
@@ -94,8 +94,8 @@ const InternsPage = () => {
   };
 
   return (
-    <div>
-      <div className={styles.container}>
+    <>
+      <div className={styles.banner}>
         <SubHeadNavbar title="Job Fair" />
         <Banner
           type="PROJECT"
@@ -104,21 +104,29 @@ const InternsPage = () => {
           text="S-TOP Job Fair는 현업에 종사하고 있는 선배 개발자님들과 실무 경험을 얻고자 하는 학생들을 연결하여, IT 인재 양성 문화를 함께 만들기 위해 기획되었습니다."
         />
       </div>
-      <div className={styles.backColor}>
-        <div className={styles.search}>
-          <h2 className={styles.title}>인턴들의 이야기</h2>
-          <div className={styles.searchArea}>
-            <SearchInput placeholder="영상 검색" onChange={(e) => setSearchQuery(e.target.value)} />
-          </div>
-          <div className={styles.dropdown}>
-            <Dropdown
-              options={YEARS}
-              placeholder="전체"
-              selectedOption={selectedYear}
-              onOptionClick={handleYearSelect}
-            />
+
+
+      <div className={styles.mainContent}>
+
+        <h2 className={styles.title}>인턴들의 이야기</h2>
+
+        <div className={styles.searchSection}>
+          <SearchInput 
+            placeholder={"인턴 인터뷰 영상 검색"}
+            onChange={(e) => setSearchQuery(e.target.value)} 
+          />
+          <div className={styles.filters}>
+            <div className={styles.dropdown}>
+              <Dropdown
+                options={YEARS}
+                placeholder="전체"
+                selectedOption={selectedYear}
+                onOptionClick={handleYearSelect}
+              />
+            </div>
           </div>
         </div>
+
         <div className={styles.videoGrid}>
           {filteredInterviews.map((interview) => (
             <div key={interview.id}>
@@ -134,7 +142,7 @@ const InternsPage = () => {
           ))}
         </div>
       </div>
-    </div>
+    </>
   );
 };
 

--- a/src/components/common/Dropdown/Dropdown.module.css
+++ b/src/components/common/Dropdown/Dropdown.module.css
@@ -1,6 +1,6 @@
 .dropdownToggle {
   padding: 10px 12px;
-  width: 300px;
+  width: clamp(180px, 35vw, 300px); 
   background-color: var(--color-inputSurface);
   border: 1px solid var(--color-inputBorder);
   border-radius: 8px;
@@ -50,7 +50,7 @@
   font-size: 14px;
   line-height: 20px;
   letter-spacing: 0.4px;
-  width: 298px;
+  width: clamp(178px, 35vw, 298px); 
 }
 
 .dropdownItem:hover {


### PR DESCRIPTION
작성자: @moony1204 
issue: #238 

## 체크 리스트

- [x] 적절한 제목으로 수정했나요?
- [x] 상단에 이슈 번호를 기입했나요?
- [x] Target Branch를 올바르게 설정했나요?
- [x] Label을 알맞게 설정했나요?

## 작업 내역

- 비디오 카드가 사용되는 페이지 중 레이아웃 수정이 필요했던 세 페이지를 수정하였습니다.
- 인터뷰, 잡페어-인턴, 잡페어-현직자 페이지의 전반적인 레이아웃을 수정하고 css를 통일하였습니다.
- 이제 비디오가 2개의 열이나 하나의 열로 뜨더라도 viewport width를 꽉 채우도록 수정되어 있습니다.
 
- 드롭다운의 모바일 디자인이슈를 드디어.. 수정해서 props나 이런 것 없이 width에 clamp를 적용하여 180~300px 사이즈로 띄워지게끔 하였습니다.

## 비고

- 드롭다운이 뭔가 기존에 뭔가 수정.. 과정이 있지 않았나 했는데? develop->main 혹은 main -> develop 과정에서 사라진건지.. 300px 고정되어 있어 수정 진행 하였습니다. 
