### PR TITLE
[ENHANCE] access token 이 만료되었을 때는 refresh token 으로 access token 을 재요청해서 사용한다. 

### DIFF
--- a/src/app/(user)/infodesk/cooperation/page.tsx
+++ b/src/app/(user)/infodesk/cooperation/page.tsx
@@ -38,12 +38,12 @@ const STOPOutlinePage = () => {
           <br />
           ◦ 기업에서 기출시된 제품들의 고객 반응 분석 후 개선방안 제시 및 개발
           <br />
-          ◦ 선생기술 탐색, 최신기술 검증, 참신한 아이디어 구현, Pilot test 등 
+          ◦ 선생기술 탐색, 최신기술 검증, 참신한 아이디어 구현, Pilot test 등
           <br />
           <br />
           ∎ 수행기간
           <br />
-          ◦ 4월~12월(약 9개월) 
+          ◦ 4월~12월(약 9개월)
           <br />
           <br />
           ∎ 산학협력프로젝트 팀 구성
@@ -53,7 +53,8 @@ const STOPOutlinePage = () => {
           <br />
           ∎ 현재까지 추진 과제 분야별 분석
           <br />
-          ◦ 머신러닝, 컴퓨터비전, 자연어처리, 빅데이터분석, 시스템&네트워크, 보안 및 SW엔제니어링, Interaction&AR, Web/App Application
+          ◦ 머신러닝, 컴퓨터비전, 자연어처리, 빅데이터분석, 시스템&네트워크, 보안 및 SW엔제니어링,
+          Interaction&AR, Web/App Application
           <br />
           <Image
             src="/images/Industry_Table2.png"

--- a/src/components/common/Auth/AuthProvider.tsx
+++ b/src/components/common/Auth/AuthProvider.tsx
@@ -1,9 +1,10 @@
 "use client";
 
 import { createContext, useCallback, useContext, useEffect, useState } from "react";
-import { JWT_COOKIE_NAME, JWT_MAX_AGE } from "@/constants/Auth";
+import { JWT_COOKIE_NAME } from "@/constants/Auth";
 import { CommonAxios } from "@/utils/CommonAxios";
 import Cookies from "js-cookie";
+import { setAccessTokenCookie } from "@/utils/auth/setAccessTokenCookie";
 
 interface AuthContextValue {
   token: string | null;
@@ -63,7 +64,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     setToken(token);
     CommonAxios.defaults.headers.Authorization = `Bearer ${token}`;
     CommonAxios.defaults.withCredentials = true;
-    Cookies.set(JWT_COOKIE_NAME, token, { "max-age": String(JWT_MAX_AGE), secure: true });
+    setAccessTokenCookie(token);
 
     setTimeout(() => {
       fetchMe(); // 토큰 설정 후 약간의 딜레이를 두고 me API 호출

--- a/src/utils/CommonAxios/CommonAxios.ts
+++ b/src/utils/CommonAxios/CommonAxios.ts
@@ -1,6 +1,6 @@
 import { JWT_COOKIE_NAME } from "@/constants/Auth";
 import { setAccessTokenCookie } from "@/utils/auth/setAccessTokenCookie";
-import axios from "axios";
+import axios, { AxiosError } from "axios";
 import Cookies from "js-cookie";
 
 /**
@@ -28,25 +28,13 @@ export const CommonAxios = axios.create({
   baseURL: process.env.NEXT_PUBLIC_API_ENDPOINT,
 });
 
-interface CustomAxiosResponseInterceptorError {
-  config: {
-    _shouldRequestBeRetriedWithReissuedAccessToken?: boolean;
-    headers: {
-      [key: string]: string;
-    };
-  };
-  response: {
-    status: number;
-  };
-}
-
 CommonAxios.interceptors.response.use(
   function (response) {
     // 2xx(200)번대 정상작동
     return response;
   },
   async function (error) {
-    const _error = error as CustomAxiosResponseInterceptorError;
+    const _error = error as AxiosError;
 
     // 인증 실패한 경우 access token 재발급 시도하고 새로고침 함.
     if (

--- a/src/utils/CommonAxios/CommonAxios.ts
+++ b/src/utils/CommonAxios/CommonAxios.ts
@@ -1,5 +1,8 @@
+import { JWT_COOKIE_NAME } from "@/constants/Auth";
 import { setAccessTokenCookie } from "@/utils/auth/setAccessTokenCookie";
 import axios from "axios";
+import Cookies from "js-cookie";
+import { redirect } from "next/navigation";
 
 /**
  * @description POST: /auth/reissue 의 응답 타입.
@@ -46,6 +49,7 @@ CommonAxios.interceptors.response.use(
   async function (error) {
     const _error = error as CustomAxiosResponseInterceptorError;
 
+    // 인증 실패한 경우 access token 재발급 시도하고 새로고침 함.
     if (
       _error.response?.status === 401 // access token 만료 포함 기타 사유로 인증 실패 시
     ) {
@@ -68,15 +72,14 @@ CommonAxios.interceptors.response.use(
         credentials: "include",
       })
         .then(() => {
-          // Cookies.remove(JWT_COOKIE_NAME);
+          Cookies.remove(JWT_COOKIE_NAME);
           CommonAxios.defaults.withCredentials = false;
-          // window.location.replace("/");
+          window.location.replace("/");
         })
         .catch((error) => console.error("Logout failed:", error));
     } else if (error.response?.status === 401) {
       // 401: 인증 실패 → 로그인 페이지(또는 메인)로 리다이렉트
-      console.log("check refresh token here");
-      // redirect("/");
+      redirect("/");
     }
     return Promise.reject(error);
   }

--- a/src/utils/CommonAxios/CommonAxios.ts
+++ b/src/utils/CommonAxios/CommonAxios.ts
@@ -1,7 +1,49 @@
-import { JWT_COOKIE_NAME } from "@/constants/Auth";
-import axios from "axios";
-import Cookies from "js-cookie";
-import { redirect } from "next/navigation";
+import { setAccessTokenCookie } from "@/utils/auth/setAccessTokenCookie";
+import axios, { AxiosRequestConfig } from "axios";
+
+interface RetryAxiosRequestConfig extends AxiosRequestConfig {
+  _shouldRequestBeRetriedWithReissuedAccessToken?: boolean;
+}
+
+type FailedQueueItem = {
+  resolve: (value?: unknown) => void;
+  reject: (reason?: unknown) => void;
+  config: RetryAxiosRequestConfig;
+};
+
+/**
+ * @description POST: /auth/reissue 의 응답 타입.
+ * refresh token 은 Set-Cookie 로 전송되므로 없음
+ */
+interface ReissueResponse {
+  accessToken: string;
+}
+
+let isGettingReissuedAccessToken = false;
+let failedRequestsQueue: FailedQueueItem[] = [];
+
+/**
+ * @description: refresh token 으로 access token 을 재발급 받은 후, 실패한 요청들을 재시도하는 함수
+ */
+const processFailedRequestsQueue = (error: unknown, reissuedAccessToken: string | null = null) => {
+  failedRequestsQueue.forEach(({ resolve, reject, config }) => {
+    if (!reissuedAccessToken) return reject(error);
+
+    config.headers = config.headers || {};
+    config.headers.Authorization = `Bearer ${reissuedAccessToken}`;
+    resolve(axios(config));
+  });
+
+  failedRequestsQueue = [];
+};
+
+const getReissuedAccessToken = async () => {
+  const res = await CommonAxios.post<ReissueResponse>("/auth/reissue", null, {
+    withCredentials: true, // refresh token 은 httpOnly 쿠키 그대로인 상태로 요청
+  });
+
+  return res.data.accessToken;
+};
 
 /**
  * 클라이언트에서 사용하는 공통 axios
@@ -12,32 +54,81 @@ export const CommonAxios = axios.create({
   baseURL: process.env.NEXT_PUBLIC_API_ENDPOINT,
 });
 
+interface CustomAxiosResponseInterceptorError {
+  config: {
+    _shouldRequestBeRetriedWithReissuedAccessToken?: boolean;
+    headers: {
+      [key: string]: string;
+    };
+  };
+  response: {
+    status: number;
+  };
+}
+
 CommonAxios.interceptors.response.use(
   function (response) {
     // 2xx(200)번대 정상작동
     return response;
   },
   async function (error) {
-    // 특정 에러 코드(4002, 3001)로 로그아웃이 필요한 상황
+    const _error = error as CustomAxiosResponseInterceptorError;
+    const originalRequest = _error.config;
+
     if (
-      error.response?.data?.code === 4002 ||
-      error.response?.data?.code === 3001 ||
-      error.response?.data?.code === 4000
+      _error.response?.status === 401 && // access token 만료 포함 기타 사유로 인증 실패 시
+      !originalRequest._shouldRequestBeRetriedWithReissuedAccessToken
     ) {
-      fetch("/auth/logout", {
-        method: "POST",
-        credentials: "include",
-      })
-        .then(() => {
-          Cookies.remove(JWT_COOKIE_NAME);
-          CommonAxios.defaults.withCredentials = false;
-          window.location.replace("/");
-        })
-        .catch((error) => console.error("Logout failed:", error));
-    } else if (error.response?.status === 401) {
-      // 401: 인증 실패 → 로그인 페이지(또는 메인)로 리다이렉트
-      redirect("/");
+      if (isGettingReissuedAccessToken) {
+        return new Promise((resolve, reject) => {
+          failedRequestsQueue.push({ resolve, reject, config: originalRequest });
+        });
+      }
+
+      originalRequest._shouldRequestBeRetriedWithReissuedAccessToken = true;
+      isGettingReissuedAccessToken = true;
+
+      try {
+        const reissuedAccessToken = await getReissuedAccessToken();
+        setAccessTokenCookie(reissuedAccessToken);
+        isGettingReissuedAccessToken = false;
+
+        CommonAxios.defaults.headers.Authorization = `Bearer ${reissuedAccessToken}`;
+        processFailedRequestsQueue(null, reissuedAccessToken);
+
+        // 기존 요청 재시도 (지금 refresh token 재발급 요청을 촉발한 요청 자체는 failedRequestsQueue 에 없으므로)
+        originalRequest.headers.Authorization = `Bearer ${reissuedAccessToken}`;
+        return CommonAxios(originalRequest);
+      } catch (err) {
+        // 기존의 refresh token 으로 access token 을 재발급 받지 못한 경우
+        processFailedRequestsQueue(err, null);
+        isGettingReissuedAccessToken = false;
+        return Promise.reject(err);
+      }
     }
+
+    // 특정 에러 코드(4002, 3001)로 로그아웃이 필요한 상황
+    // TODO: 여기 처리 필요함
+    // if (
+    //   error.response?.data?.code === 4002 ||
+    //   error.response?.data?.code === 3001 ||
+    //   error.response?.data?.code === 4000
+    // ) {
+    //   fetch("/auth/logout", {
+    //     method: "POST",
+    //     credentials: "include",
+    //   })
+    //     .then(() => {
+    //       // Cookies.remove(JWT_COOKIE_NAME);
+    //       CommonAxios.defaults.withCredentials = false;
+    //       // window.location.replace("/");
+    //     })
+    //     .catch((error) => console.error("Logout failed:", error));
+    // } else if (error.response?.status === 401) {
+    //   // 401: 인증 실패 → 로그인 페이지(또는 메인)로 리다이렉트
+    //   console.log("check refresh token here");
+    //   // redirect("/");
+    // }
     return Promise.reject(error);
   }
 );

--- a/src/utils/CommonAxios/CommonAxios.ts
+++ b/src/utils/CommonAxios/CommonAxios.ts
@@ -2,7 +2,6 @@ import { JWT_COOKIE_NAME } from "@/constants/Auth";
 import { setAccessTokenCookie } from "@/utils/auth/setAccessTokenCookie";
 import axios from "axios";
 import Cookies from "js-cookie";
-import { redirect } from "next/navigation";
 
 /**
  * @description POST: /auth/reissue 의 응답 타입.
@@ -77,9 +76,6 @@ CommonAxios.interceptors.response.use(
           window.location.replace("/");
         })
         .catch((error) => console.error("Logout failed:", error));
-    } else if (error.response?.status === 401) {
-      // 401: 인증 실패 → 로그인 페이지(또는 메인)로 리다이렉트
-      redirect("/");
     }
     return Promise.reject(error);
   }

--- a/src/utils/CommonAxios/CommonAxios.ts
+++ b/src/utils/CommonAxios/CommonAxios.ts
@@ -58,26 +58,26 @@ CommonAxios.interceptors.response.use(
 
     // 특정 에러 코드(4002, 3001)로 로그아웃이 필요한 상황
     // TODO: 여기 처리 필요함
-    // if (
-    //   error.response?.data?.code === 4002 ||
-    //   error.response?.data?.code === 3001 ||
-    //   error.response?.data?.code === 4000
-    // ) {
-    //   fetch("/auth/logout", {
-    //     method: "POST",
-    //     credentials: "include",
-    //   })
-    //     .then(() => {
-    //       // Cookies.remove(JWT_COOKIE_NAME);
-    //       CommonAxios.defaults.withCredentials = false;
-    //       // window.location.replace("/");
-    //     })
-    //     .catch((error) => console.error("Logout failed:", error));
-    // } else if (error.response?.status === 401) {
-    //   // 401: 인증 실패 → 로그인 페이지(또는 메인)로 리다이렉트
-    //   console.log("check refresh token here");
-    //   // redirect("/");
-    // }
+    if (
+      error.response?.data?.code === 4002 ||
+      error.response?.data?.code === 3001 ||
+      error.response?.data?.code === 4000
+    ) {
+      fetch("/auth/logout", {
+        method: "POST",
+        credentials: "include",
+      })
+        .then(() => {
+          // Cookies.remove(JWT_COOKIE_NAME);
+          CommonAxios.defaults.withCredentials = false;
+          // window.location.replace("/");
+        })
+        .catch((error) => console.error("Logout failed:", error));
+    } else if (error.response?.status === 401) {
+      // 401: 인증 실패 → 로그인 페이지(또는 메인)로 리다이렉트
+      console.log("check refresh token here");
+      // redirect("/");
+    }
     return Promise.reject(error);
   }
 );

--- a/src/utils/auth/setAccessTokenCookie.ts
+++ b/src/utils/auth/setAccessTokenCookie.ts
@@ -1,0 +1,8 @@
+import { JWT_COOKIE_NAME, JWT_MAX_AGE } from "@/constants/Auth";
+import Cookies from "js-cookie";
+
+// access token 을 브라우저에 non-httpOnly 쿠키로 지정하는 함수.
+// TODO: 경고! 이 방식의 토큰 저장의 경우 보안상 매우 취약합니다. 추후 인 메모리 저장 방식 등으로 개편을 검토해야 합니다.
+export const setAccessTokenCookie = (token: string) => {
+  Cookies.set(JWT_COOKIE_NAME, token, { "max-age": String(JWT_MAX_AGE), secure: true });
+};


### PR DESCRIPTION
작성자: @jaychang99

# ⚠️ 우선 예외가 많아 401 수신 시 페이지 전체를 새로고침하기로 함. 추후에는 swr 등을 이용해 아래와 같은 방식으로 구현하면 어떨까 싶음. 

## 체크 리스트

- [x] 적절한 제목으로 수정했나요?
- [x] 상단(하단)에 이슈 번호를 기입했나요?
- [x] Target Branch를 올바르게 설정했나요?
- [x] Label을 알맞게 설정했나요?

## 작업 내역

개념도
![image](https://github.com/user-attachments/assets/67c730a0-7326-4ae6-820a-4909deddd85f)



- access token 이 만료되었을 때는 refresh token 으로 access token 을 재요청해서 사용하게 합니다. 
- 기본적인 아이디어는 access token 을 이용한 기존 요청들이 '권한 없음 (status code = 401)' 의 이유로 실패한 경우 기존에 갖고 있던 refresh token 을 이용해 신규 access token 을 발급받는 것입니다. 실패한 요청들은 `failedRequestsQueue` 에 들어갑니다. 
- 이 과정에서 동시에 다수의 요청이 401 에러를 받으며 실패할 수 있으므로 `isGettingReissuedAccessToken` 으로 일종의 락 (lock) 을 걸어서 access token 재발급 요청은 1회만 갈 수 있도록 합니다. 
- refresh token 으로 성공적으로 신규 access token 을 발급받은 후에는 이전에 401 실패 응답을 받았던 요청들을 다시 요청하여 성공 응답을 받아내는 구조
![image](https://github.com/user-attachments/assets/6d991555-c7b4-4f98-943d-436c8314c460)


## 비고

- 현재 tanstack/react-query 와 같은 비동기 상태 (서버 상태) 관리 라이브러리를 사용하고 있지 않아서, 중복되는 요청이 굉장히 많이 가고 있습니다. 이부분은 향후 최적화 여지가 있습니다. 
  - 다만, 직접 cache mechanism, request deduplication 등과 같은 것을 구현하는 것은 바퀴의 재발명이라고 생각을 합니다. 가능하다면 swr 또는 react-query 등과 같은 라이브러리를 스터디하고 적용을 하게 할 수도 있을 것 같습니다. 
- access token 의 경우 클라이언트 사이드에서 (기존에도) 세팅하는 구조여서 보안상 아주 좋은 practice 는 아닌 것 같습니다. 추후에는 access token 의 경우 in-memory 에 저장하게 하는 방법을 검토해보는 것도 좋을 것 같습니다. 


closes #239 
