### PR TITLE
중복 수상 프로젝트 임시로 하드코딩

### DIFF
--- a/src/components/pages/EventAwardView/EventAwardView.tsx
+++ b/src/components/pages/EventAwardView/EventAwardView.tsx
@@ -137,7 +137,16 @@ export function EventAwardView() {
           const thumbnailUrl = thumbnailUrls[idx];
           return (
             <div key={idx}>
-              <Text className={classes.awardType}>{AWARD_TYPE_LOOKUP_TABLE[data.awardStatus]}</Text>
+              <Text className={classes.awardType}>
+                {/* TODO: 중복 수상 하드코딩 제거 필요 */}
+                {(() => {
+                  const legend = [699, 706];
+                  if (legend.includes(data.id)) {
+                    return "장려상/인기상";
+                  }
+                  return AWARD_TYPE_LOOKUP_TABLE[data.awardStatus];
+                })()}
+              </Text>
               <ProjectCard
                 data={data}
                 thumbnailUrl={thumbnailUrl}


### PR DESCRIPTION
작성자: @snghyn28 

## 체크 리스트

- [x] 적절한 제목으로 수정했나요?
- [ ] 상단에 이슈 번호를 기입했나요?
- [x] Target Branch를 올바르게 설정했나요?
- [ ] Label을 알맞게 설정했나요?

## 작업 내역

**배경**

2026 S-TOP 시상팀으로부터 특정 프로젝트 2건(ID: 699, 706)이 장려상과 인기상을 동시에 수상했다는 연락을 받았습니다. 그런데 현재 DB 스키마상 프로젝트와 수상 정보가 1:1 관계(칼럼 하나)로 설계되어 있어서, 하나의 프로젝트에 복수의 상을 부여하는 것이 구조적으로 불가능한 상태입니다.

**이 PR이 하는 일**

DB 스키마 변경 없이, 프론트엔드에서 해당 2건의 프로젝트 ID를 직접 참조하여 수상 표기를 `장려상` → `장려상/인기상`으로 오버라이드합니다. 의도적인 하드코딩이며 임시 조치입니다.

**왜 하드코딩인가**

근본적으로는 프로젝트-수상 관계를 1:N 혹은 M:N으로 변경하고, 백엔드 API와 프론트 렌더링을 모두 수정해야 합니다. 다만 이번 건은 시상팀 요청에 대한 긴급 대응이라 프론트 단독 임시 처리로 진행했습니다.

**향후 해야 할 일 (TODO)**

- DB 스키마를 프로젝트-수상 다대다(M:N) 관계로 마이그레이션
- 백엔드 API에서 복수 수상 정보를 반환하도록 수정
- 프론트에서 복수 수상을 일반 로직으로 렌더링하도록 변경
- 위 작업 완료 후 이 하드코딩 제거 (`TODO` 주석 참조)

**관련 컨텍스트**

- [(Slack 스레드 링크)](https://systemconsult-vqd4955.slack.com/archives/C079TP0861Y/p1775186616078489)