### PR TITLE
[FEAT] 한 프로젝트가 여러 수상 목록을 가질 수 있도록 변경

### DIFF
--- a/src/components/common/ProjectCard/_mock/mock-project.ts
+++ b/src/components/common/ProjectCard/_mock/mock-project.ts
@@ -26,7 +26,7 @@ export const MockProjectData: IProjectContent = {
   professorNames: ["교수 이름 1"],
   projectType: "STARTUP",
   projectCategory: "BIG_DATA_ANALYSIS",
-  awardStatus: "FIRST",
+  awardStatuses: ["FIRST"],
   year: 2023,
   likeCount: 100,
   like: false,

--- a/src/components/common/ProjectCard/_mock/mock-project.ts
+++ b/src/components/common/ProjectCard/_mock/mock-project.ts
@@ -26,7 +26,7 @@ export const MockProjectData: IProjectContent = {
   professorNames: ["교수 이름 1"],
   projectType: "STARTUP",
   projectCategory: "BIG_DATA_ANALYSIS",
-  awardStatuses: ["FIRST"],
+  awards: ["FIRST"],
   year: 2023,
   likeCount: 100,
   like: false,

--- a/src/components/pages/AdminProjectsEditSection/ProjectCreateSection.tsx
+++ b/src/components/pages/AdminProjectsEditSection/ProjectCreateSection.tsx
@@ -10,7 +10,7 @@ import { useEffect, useState } from "react";
 import { PrimaryButton } from "@/components/common/Buttons";
 import { isNotEmpty, useForm } from "@mantine/form";
 import { getYears } from "@/utils/getYears";
-import { ProjectAwardStatus, ProjectCategory, ProjectType } from "@/types/project";
+import { ProjectAward, ProjectCategory, ProjectType } from "@/types/project";
 import {
   ProjectsCategoryLookupTable,
   ProjectsTypeLookupTable,
@@ -18,7 +18,7 @@ import {
 import { useRouter } from "next/navigation";
 import { useFiles } from "@/hooks/useFiles/useFiles";
 import { CommonAxios } from "@/utils/CommonAxios";
-import { ProjectsAwardStatusLookupTable } from "@/constants/LookupTables/ProjectsAwardStatusLookupTable";
+import { ProjectsAwardLookupTable } from "@/constants/LookupTables/ProjectsAwardLookupTable";
 
 type Role = "PROFESSOR" | "STUDENT";
 
@@ -36,7 +36,7 @@ export interface ProjectEditFormInputs {
   teamName: string;
   youtubeId: string;
   year: number;
-  awardStatuses: ProjectAwardStatus[];
+  awards: ProjectAward[];
   members: Member[];
   url: string;
   description: string;
@@ -56,7 +56,7 @@ export function ProjectCreateSection({ projectId }: { projectId?: number }) {
       teamName: "",
       youtubeId: "",
       year: 0,
-      awardStatuses: [],
+      awards: [],
       members: [],
       url: "",
       description: "",
@@ -112,7 +112,7 @@ export function ProjectCreateSection({ projectId }: { projectId?: number }) {
         teamName: values.teamName,
         youtubeId: values.youtubeId,
         year: Number(option),
-        awardStatuses: values.awardStatuses,
+        awards: values.awards,
         members: members,
         url: values.url,
         description: values.description,
@@ -155,7 +155,7 @@ export function ProjectCreateSection({ projectId }: { projectId?: number }) {
         teamName: prevProject.teamName,
         youtubeId: prevProject.youtubeId,
         year: prevProject.year,
-        awardStatuses: prevProject.awardStatuses,
+        awards: prevProject.awards,
         members: prevMembers,
         url: prevProject.url,
         description: prevProject.description,
@@ -323,25 +323,16 @@ export function ProjectCreateSection({ projectId }: { projectId?: number }) {
             />
           </Row>
           <Row field="수상 목록" fieldSize={130} mt={20}>
-            <Checkbox.Group {...getInputProps("awardStatuses")}>
+            <Checkbox.Group {...getInputProps("awards")}>
               <Group gap={20}>
-                <Checkbox value={ProjectsAwardStatusLookupTable["대상"]} label={"대상"}></Checkbox>
+                <Checkbox value={ProjectsAwardLookupTable["대상"]} label={"대상"}></Checkbox>
                 <Checkbox
-                  value={ProjectsAwardStatusLookupTable["최우수상"]}
+                  value={ProjectsAwardLookupTable["최우수상"]}
                   label={"최우수상"}
                 ></Checkbox>
-                <Checkbox
-                  value={ProjectsAwardStatusLookupTable["우수상"]}
-                  label={"우수상"}
-                ></Checkbox>
-                <Checkbox
-                  value={ProjectsAwardStatusLookupTable["인기상"]}
-                  label={"인기상"}
-                ></Checkbox>
-                <Checkbox
-                  value={ProjectsAwardStatusLookupTable["장려상"]}
-                  label={"장려상"}
-                ></Checkbox>
+                <Checkbox value={ProjectsAwardLookupTable["우수상"]} label={"우수상"}></Checkbox>
+                <Checkbox value={ProjectsAwardLookupTable["인기상"]} label={"인기상"}></Checkbox>
+                <Checkbox value={ProjectsAwardLookupTable["장려상"]} label={"장려상"}></Checkbox>
               </Group>
             </Checkbox.Group>
           </Row>

--- a/src/components/pages/AdminProjectsEditSection/ProjectCreateSection.tsx
+++ b/src/components/pages/AdminProjectsEditSection/ProjectCreateSection.tsx
@@ -3,7 +3,7 @@
 import { Row } from "@/components/common/Row";
 import { Section } from "@/components/common/Section";
 import { TextInput } from "@/components/common/TextInput";
-import { FileInput, Group, Radio, RadioGroup, Stack, Title } from "@mantine/core";
+import { FileInput, Group, Radio, RadioGroup, Stack, Title, Checkbox } from "@mantine/core";
 import classes from "./AdminProjectsEditSection.module.css";
 import { Dropdown } from "@/components/common/Dropdown/Dropdown";
 import { useEffect, useState } from "react";
@@ -36,7 +36,7 @@ export interface ProjectEditFormInputs {
   teamName: string;
   youtubeId: string;
   year: number;
-  awardStatus: ProjectAwardStatus;
+  awardStatuses: ProjectAwardStatus[];
   members: Member[];
   url: string;
   description: string;
@@ -56,7 +56,7 @@ export function ProjectCreateSection({ projectId }: { projectId?: number }) {
       teamName: "",
       youtubeId: "",
       year: 0,
-      awardStatus: "NONE",
+      awardStatuses: [],
       members: [],
       url: "",
       description: "",
@@ -112,7 +112,7 @@ export function ProjectCreateSection({ projectId }: { projectId?: number }) {
         teamName: values.teamName,
         youtubeId: values.youtubeId,
         year: Number(option),
-        awardStatus: values.awardStatus,
+        awardStatuses: values.awardStatuses,
         members: members,
         url: values.url,
         description: values.description,
@@ -155,7 +155,7 @@ export function ProjectCreateSection({ projectId }: { projectId?: number }) {
         teamName: prevProject.teamName,
         youtubeId: prevProject.youtubeId,
         year: prevProject.year,
-        awardStatus: prevProject.awardStatus,
+        awardStatuses: prevProject.awardStatuses,
         members: prevMembers,
         url: prevProject.url,
         description: prevProject.description,
@@ -322,18 +322,28 @@ export function ProjectCreateSection({ projectId }: { projectId?: number }) {
               w={"50%"}
             />
           </Row>
-          <Row field="수상 내역" fieldSize={130} mt={20}>
-            <RadioGroup {...getInputProps("awardStatus")}>
+          <Row field="수상 목록" fieldSize={130} mt={20}>
+            <Checkbox.Group {...getInputProps("awardStatuses")}>
               <Group gap={20}>
-                <Radio value={ProjectsAwardStatusLookupTable["대상"]} label={"대상"}></Radio>
-                <Radio
+                <Checkbox value={ProjectsAwardStatusLookupTable["대상"]} label={"대상"}></Checkbox>
+                <Checkbox
                   value={ProjectsAwardStatusLookupTable["최우수상"]}
                   label={"최우수상"}
-                ></Radio>
-                <Radio value={ProjectsAwardStatusLookupTable["우수상"]} label={"우수상"}></Radio>
-                <Radio value={ProjectsAwardStatusLookupTable["인기상"]} label={"인기상"}></Radio>
+                ></Checkbox>
+                <Checkbox
+                  value={ProjectsAwardStatusLookupTable["우수상"]}
+                  label={"우수상"}
+                ></Checkbox>
+                <Checkbox
+                  value={ProjectsAwardStatusLookupTable["인기상"]}
+                  label={"인기상"}
+                ></Checkbox>
+                <Checkbox
+                  value={ProjectsAwardStatusLookupTable["장려상"]}
+                  label={"장려상"}
+                ></Checkbox>
               </Group>
-            </RadioGroup>
+            </Checkbox.Group>
           </Row>
           <Group justify="center" mt={30}>
             {projectId && (

--- a/src/components/pages/EventAwardView/EventAwardView.tsx
+++ b/src/components/pages/EventAwardView/EventAwardView.tsx
@@ -138,7 +138,7 @@ export function EventAwardView() {
           return (
             <div key={idx}>
               <Text className={classes.awardType}>
-                {data.awardStatuses?.map((status) => AWARD_TYPE_LOOKUP_TABLE[status]).join("/")}
+                {data.awards?.map((status) => AWARD_TYPE_LOOKUP_TABLE[status]).join("/")}
               </Text>
               <ProjectCard
                 data={data}

--- a/src/components/pages/EventAwardView/EventAwardView.tsx
+++ b/src/components/pages/EventAwardView/EventAwardView.tsx
@@ -138,7 +138,9 @@ export function EventAwardView() {
           return (
             <div key={idx}>
               <Text className={classes.awardType}>
-                {data.awardStatuses?.map((status) => AWARD_TYPE_LOOKUP_TABLE[status]).join("/")}
+                {(data.awardStatuses ?? [])
+                  .map((status) => AWARD_TYPE_LOOKUP_TABLE[status])
+                  .join("/")}
               </Text>
               <ProjectCard
                 data={data}

--- a/src/components/pages/EventAwardView/EventAwardView.tsx
+++ b/src/components/pages/EventAwardView/EventAwardView.tsx
@@ -138,14 +138,7 @@ export function EventAwardView() {
           return (
             <div key={idx}>
               <Text className={classes.awardType}>
-                {/* TODO: 중복 수상 하드코딩 제거 필요 */}
-                {(() => {
-                  const legend = [699, 706];
-                  if (legend.includes(data.id)) {
-                    return "장려상/인기상";
-                  }
-                  return AWARD_TYPE_LOOKUP_TABLE[data.awardStatus];
-                })()}
+                {data.awardStatuses?.map((status) => AWARD_TYPE_LOOKUP_TABLE[status]).join("/")}
               </Text>
               <ProjectCard
                 data={data}

--- a/src/components/pages/ProjectDetail/_type/project.ts
+++ b/src/components/pages/ProjectDetail/_type/project.ts
@@ -20,7 +20,7 @@ export interface ProjectDetailDto {
   teamName: string;
   youtubeId: string;
   year: number;
-  awardStatuses: string[]; //FIRST, SECOND, THIRD, FOURTH, FIFTH
+  awards: string[]; //FIRST, SECOND, THIRD, FOURTH, FIFTH
   studentNames: string[];
   professorNames: string[];
   likeCount: number;

--- a/src/components/pages/ProjectDetail/_type/project.ts
+++ b/src/components/pages/ProjectDetail/_type/project.ts
@@ -20,7 +20,7 @@ export interface ProjectDetailDto {
   teamName: string;
   youtubeId: string;
   year: number;
-  awardStatus: string; //NONE, FIRST, SECOND, THIRD, FOURTH, FIFTH
+  awardStatuses: string[]; //FIRST, SECOND, THIRD, FOURTH, FIFTH
   studentNames: string[];
   professorNames: string[];
   likeCount: number;

--- a/src/constants/LookupTables.ts
+++ b/src/constants/LookupTables.ts
@@ -1,4 +1,4 @@
-import { ProjectAwardStatus } from "@/types/project";
+import { ProjectAward } from "@/types/project";
 import { Role } from "@/types/user";
 
 export const USER_TYPE_LOOKUP_TABLE: Record<Role, string> = {
@@ -13,7 +13,7 @@ export const USER_TYPE_LOOKUP_TABLE: Record<Role, string> = {
   TEMP: "임시",
 };
 
-export const AWARD_TYPE_LOOKUP_TABLE: Record<ProjectAwardStatus, string> = {
+export const AWARD_TYPE_LOOKUP_TABLE: Record<ProjectAward, string> = {
   FIRST: "대상",
   SECOND: "최우수상",
   THIRD: "우수상",

--- a/src/constants/LookupTables.ts
+++ b/src/constants/LookupTables.ts
@@ -14,7 +14,6 @@ export const USER_TYPE_LOOKUP_TABLE: Record<Role, string> = {
 };
 
 export const AWARD_TYPE_LOOKUP_TABLE: Record<ProjectAwardStatus, string> = {
-  NONE: "미정",
   FIRST: "대상",
   SECOND: "최우수상",
   THIRD: "우수상",

--- a/src/constants/LookupTables/ProjectsAwardLookupTable.ts
+++ b/src/constants/LookupTables/ProjectsAwardLookupTable.ts
@@ -1,4 +1,4 @@
-export const ProjectsAwardStatusLookupTable = {
+export const ProjectsAwardLookupTable = {
   대상: "FIRST",
   최우수상: "SECOND",
   우수상: "THIRD",

--- a/src/constants/LookupTables/ProjectsAwardStatusLookupTable.ts
+++ b/src/constants/LookupTables/ProjectsAwardStatusLookupTable.ts
@@ -1,7 +1,7 @@
 export const ProjectsAwardStatusLookupTable = {
-  미정: "NONE",
   대상: "FIRST",
   최우수상: "SECOND",
   우수상: "THIRD",
   인기상: "FOURTH",
+  장려상: "FIFTH",
 };

--- a/src/types/project.ts
+++ b/src/types/project.ts
@@ -24,7 +24,7 @@ export interface IProjectContent {
   professorNames: string[];
   projectType: ProjectType;
   projectCategory: ProjectCategory;
-  awardStatus: ProjectAwardStatus;
+  awardStatuses: ProjectAwardStatus[];
   year: number;
   likeCount: number;
   like: boolean;
@@ -45,6 +45,6 @@ export type ProjectCategory =
   | "AI_MACHINE_LEARNING"
   | "INTERACTION_AUGMENTED_REALITY";
 
-export type ProjectAwardStatus = "NONE" | "FIRST" | "SECOND" | "THIRD" | "FOURTH" | "FIFTH";
+export type ProjectAwardStatus = "FIRST" | "SECOND" | "THIRD" | "FOURTH" | "FIFTH";
 
 export interface IProjectResponse extends PagedApiResponse<IProjectContent> {}

--- a/src/types/project.ts
+++ b/src/types/project.ts
@@ -24,7 +24,7 @@ export interface IProjectContent {
   professorNames: string[];
   projectType: ProjectType;
   projectCategory: ProjectCategory;
-  awardStatuses: ProjectAwardStatus[];
+  awards: ProjectAward[];
   year: number;
   likeCount: number;
   like: boolean;
@@ -45,6 +45,6 @@ export type ProjectCategory =
   | "AI_MACHINE_LEARNING"
   | "INTERACTION_AUGMENTED_REALITY";
 
-export type ProjectAwardStatus = "FIRST" | "SECOND" | "THIRD" | "FOURTH" | "FIFTH";
+export type ProjectAward = "FIRST" | "SECOND" | "THIRD" | "FOURTH" | "FIFTH";
 
 export interface IProjectResponse extends PagedApiResponse<IProjectContent> {}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,7 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "react-jsx",
+    "jsx": "preserve",
     "incremental": true,
     "plugins": [
       {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,7 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "preserve",
+    "jsx": "react-jsx",
     "incremental": true,
     "plugins": [
       {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,15 +1,7 @@
 {
   "compilerOptions": {
-    "types": [
-      "node",
-      "jest",
-      "@testing-library/jest-dom"
-    ],
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
+    "types": ["node", "jest", "@testing-library/jest-dom"],
+    "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -27,9 +19,7 @@
       }
     ],
     "paths": {
-      "@/*": [
-        "./src/*"
-      ]
+      "@/*": ["./src/*"]
     },
     "target": "ES2017"
   },
@@ -41,7 +31,5 @@
     "src/hooks/useQuizs",
     ".next/dev/types/**/*.ts"
   ],
-  "exclude": [
-    "node_modules"
-  ]
+  "exclude": ["node_modules"]
 }


### PR DESCRIPTION
작성자: @snghyn28 

[https://github.com/SystemConsultantGroup/S-top-backend/issues/176](이슈)

## 체크 리스트

- [x] 적절한 제목으로 수정했나요?
- [x] 상단에 이슈 번호를 기입했나요?
- [x] Target Branch를 올바르게 설정했나요?
- [x] Label을 알맞게 설정했나요?

## 작업 내역

- 변경된 API 구조에 맞춰 데이터 타입을 수정하고, UI에서 여러 개의 수상 내역을 조회 및 수정할 수 있도록 변경
